### PR TITLE
Fix: Platform tenantAdminControls cascade via tenant id 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ logs/
 .env.local
 .env.*.local
 *.local.properties
+application-local.properties
 
 # =============================================================================
 # OS files

--- a/api/tenantservice.yaml
+++ b/api/tenantservice.yaml
@@ -706,6 +706,9 @@ components:
         calls:
           type: boolean
           example: "true"
+        groupChat:
+          type: boolean
+          example: "true"
         supervision:
           type: boolean
           example: "true"

--- a/src/main/java/com/vi/tenantservice/api/converter/TenantConverter.java
+++ b/src/main/java/com/vi/tenantservice/api/converter/TenantConverter.java
@@ -376,7 +376,7 @@ public class TenantConverter {
         .activeLanguages(nullAsGerman(tenantSettings.getActiveLanguages()));
   }
 
-  private TenantAdminControlsSettings toTenantAdminControlsSettings(
+  public TenantAdminControlsSettings toTenantAdminControlsSettings(
       TenantAdminControls tenantAdminControls) {
     if (tenantAdminControls == null) {
       return null;
@@ -398,6 +398,7 @@ public class TenantConverter {
         .appearance(nullAsTrue(allowedPermissionToggles.getAppearance()))
         .anonymousChat(nullAsTrue(allowedPermissionToggles.getAnonymousChat()))
         .calls(nullAsTrue(allowedPermissionToggles.getCalls()))
+        .groupChat(nullAsTrue(allowedPermissionToggles.getGroupChat()))
         .supervision(nullAsTrue(allowedPermissionToggles.getSupervision()))
         .supervisionAnonymousChats(
             nullAsTrue(allowedPermissionToggles.getSupervisionAnonymousChats()))
@@ -433,7 +434,7 @@ public class TenantConverter {
         .build();
   }
 
-  private TenantAdminControls toTenantAdminControls(
+  public TenantAdminControls toTenantAdminControls(
       TenantAdminControlsSettings tenantAdminControlsSettings) {
     if (tenantAdminControlsSettings == null) {
       return null;
@@ -454,6 +455,7 @@ public class TenantConverter {
         .appearance(nullAsTrue(allowedPermissionTogglesSettings.getAppearance()))
         .anonymousChat(nullAsTrue(allowedPermissionTogglesSettings.getAnonymousChat()))
         .calls(nullAsTrue(allowedPermissionTogglesSettings.getCalls()))
+        .groupChat(nullAsTrue(allowedPermissionTogglesSettings.getGroupChat()))
         .supervision(nullAsTrue(allowedPermissionTogglesSettings.getSupervision()))
         .supervisionAnonymousChats(
             nullAsTrue(allowedPermissionTogglesSettings.getSupervisionAnonymousChats()))

--- a/src/main/java/com/vi/tenantservice/api/facade/TenantAdminControlsCascadeService.java
+++ b/src/main/java/com/vi/tenantservice/api/facade/TenantAdminControlsCascadeService.java
@@ -1,0 +1,158 @@
+package com.vi.tenantservice.api.facade;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.RuntimeJsonMappingException;
+import com.vi.tenantservice.api.converter.TenantConverter;
+import com.vi.tenantservice.api.model.MultilingualTenantDTO;
+import com.vi.tenantservice.api.model.Settings;
+import com.vi.tenantservice.api.model.TenantAdminAllowedPermissionTogglesSettings;
+import com.vi.tenantservice.api.model.TenantAdminControls;
+import com.vi.tenantservice.api.model.TenantAdminControlsSettings;
+import com.vi.tenantservice.api.model.TenantEntity;
+import com.vi.tenantservice.api.model.TenantSettings;
+import com.vi.tenantservice.api.service.TenantService;
+import com.vi.tenantservice.api.util.JsonConverter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class TenantAdminControlsCascadeService {
+
+  /**
+   * Platform-level tenant admin controls are edited via {@code PUT /tenantadmin/1} in the admin UI.
+   * Updates to other tenants must not change {@code tenantAdminControls}.
+   */
+  private static final Long PLATFORM_TENANT_ID = 1L;
+
+  private final @NonNull TenantConverter tenantConverter;
+  private final @NonNull TenantService tenantService;
+
+  public void preserveTenantAdminControlsUnlessPlatformTenant(
+      MultilingualTenantDTO sanitizedTenantDTO, TenantEntity existingTenantEntity) {
+    if (PLATFORM_TENANT_ID.equals(existingTenantEntity.getId())) {
+      return;
+    }
+    if (sanitizedTenantDTO.getSettings() == null) {
+      return;
+    }
+    sanitizedTenantDTO
+        .getSettings()
+        .setTenantAdminControls(
+            tenantConverter.toTenantAdminControls(
+                getTenantAdminControlsFromSettings(existingTenantEntity.getSettings())));
+  }
+
+  public void cascadeTenantAdminControlsIfPlatformTenant(
+      MultilingualTenantDTO sanitizedTenantDTO, Long updatedTenantId, String previousSettingsJson) {
+    if (!PLATFORM_TENANT_ID.equals(updatedTenantId)) {
+      return;
+    }
+    log.info("Cascading tenant admin controls from platform tenant {}", PLATFORM_TENANT_ID);
+
+    TenantAdminControls tenantAdminControls = getTenantAdminControls(sanitizedTenantDTO);
+    if (tenantAdminControls == null || tenantAdminControls.getAllowedPermissionToggles() == null) {
+      log.info("Tenant admin controls or allowed permission toggles is null");
+      return;
+    }
+
+    TenantAdminControlsSettings tenantAdminControlsSettings =
+        tenantConverter.toTenantAdminControlsSettings(tenantAdminControls);
+
+    if (!tenantAdminControlsChanged(previousSettingsJson, tenantAdminControlsSettings)) {
+      log.info("Tenant admin controls are not changed");
+      return;
+    }
+
+    cascadeToAllTenants(tenantAdminControlsSettings, updatedTenantId);
+  }
+
+  private TenantAdminControls getTenantAdminControls(MultilingualTenantDTO sanitizedTenantDTO) {
+    Settings settings = sanitizedTenantDTO.getSettings();
+    return settings != null ? settings.getTenantAdminControls() : null;
+  }
+
+  private boolean tenantAdminControlsChanged(
+      String previousSettingsJson, TenantAdminControlsSettings newTenantAdminControls) {
+    TenantAdminControlsSettings previousTenantAdminControls =
+        getTenantAdminControlsFromSettings(previousSettingsJson);
+    return !Objects.equals(
+        JsonConverter.convertToJson(previousTenantAdminControls),
+        JsonConverter.convertToJson(newTenantAdminControls));
+  }
+
+  private TenantAdminControlsSettings getTenantAdminControlsFromSettings(String settingsJson) {
+    if (settingsJson == null) {
+      return null;
+    }
+    TenantSettings tenantSettings = JsonConverter.convertFromJson(settingsJson);
+    return tenantSettings.getTenantAdminControls();
+  }
+
+  private void cascadeToAllTenants(
+      TenantAdminControlsSettings tenantAdminControlsSettings, Long updatedTenantId) {
+    TenantAdminControlsSettings controlsCopy = deepCopy(tenantAdminControlsSettings);
+    Map<Long, String> settingsByTenantId = new HashMap<>();
+
+    tenantService.getAllTenants().stream()
+        .filter(tenant -> !tenant.getId().equals(updatedTenantId))
+        .forEach(
+            tenant -> {
+              TenantSettings settings =
+                  tenant.getSettings() == null
+                      ? new TenantSettings()
+                      : JsonConverter.convertFromJson(tenant.getSettings());
+              applyTenantAdminControls(settings, controlsCopy);
+              settingsByTenantId.put(tenant.getId(), JsonConverter.convertToJson(settings));
+            });
+
+    if (settingsByTenantId.isEmpty()) {
+      return;
+    }
+
+    tenantService.updateTenantSettingsBatch(settingsByTenantId);
+    log.info(
+        "Cascaded tenantAdminControls.allowedPermissionToggles to {} tenants",
+        settingsByTenantId.size());
+  }
+
+  private void applyTenantAdminControls(
+      TenantSettings settings, TenantAdminControlsSettings tenantAdminControlsSettings) {
+    TenantAdminControlsSettings existingControls = settings.getTenantAdminControls();
+    if (existingControls == null) {
+      settings.setTenantAdminControls(deepCopy(tenantAdminControlsSettings));
+      return;
+    }
+    existingControls.setAllowedPermissionToggles(
+        deepCopy(tenantAdminControlsSettings.getAllowedPermissionToggles()));
+  }
+
+  private TenantAdminControlsSettings deepCopy(TenantAdminControlsSettings source) {
+    try {
+      ObjectMapper objectMapper = new ObjectMapper();
+      return objectMapper.readValue(
+          objectMapper.writeValueAsString(source), TenantAdminControlsSettings.class);
+    } catch (JsonProcessingException exception) {
+      throw new RuntimeJsonMappingException(exception.getMessage());
+    }
+  }
+
+  private TenantAdminAllowedPermissionTogglesSettings deepCopy(
+      TenantAdminAllowedPermissionTogglesSettings source) {
+    try {
+      ObjectMapper objectMapper = new ObjectMapper();
+      return objectMapper.readValue(
+          objectMapper.writeValueAsString(source),
+          TenantAdminAllowedPermissionTogglesSettings.class);
+    } catch (JsonProcessingException exception) {
+      throw new RuntimeJsonMappingException(exception.getMessage());
+    }
+  }
+}

--- a/src/main/java/com/vi/tenantservice/api/facade/TenantServiceFacade.java
+++ b/src/main/java/com/vi/tenantservice/api/facade/TenantServiceFacade.java
@@ -83,6 +83,8 @@ public class TenantServiceFacade {
   private final @NonNull TenantFacadeDependentSettingsOverrideService
       tenantFacadeDependentSettingsOverrideService;
 
+  private final @NonNull TenantAdminControlsCascadeService tenantAdminControlsCascadeService;
+
   private final @NonNull TenantResolverService tenantResolverService;
 
   private final @NonNull SingleDomainTenantOverrideService singleDomainTenantOverrideService;
@@ -292,10 +294,15 @@ public class TenantServiceFacade {
         sanitizedTenantDTO, existingTenantEntity);
     tenantFacadeDependentSettingsOverrideService.overrideDependentSettingsOnUpdate(
         sanitizedTenantDTO, existingTenantEntity);
+    tenantAdminControlsCascadeService.preserveTenantAdminControlsUnlessPlatformTenant(
+        sanitizedTenantDTO, existingTenantEntity);
+    String previousSettingsJson = existingTenantEntity.getSettings();
     var updatedEntity = tenantConverter.toEntity(existingTenantEntity, sanitizedTenantDTO);
     setContentActivationDates(updatedEntity, sanitizedTenantDTO);
     updatedEntity = tenantService.update(updatedEntity);
     updateExtendedSettingsAsConsultingType(sanitizedTenantDTO, existingTenantEntity.getId());
+    tenantAdminControlsCascadeService.cascadeTenantAdminControlsIfPlatformTenant(
+        sanitizedTenantDTO, existingTenantEntity.getId(), previousSettingsJson);
     log.info("Tenant with id {} updated", existingTenantEntity.getId());
     return getConvertedAndEnrichedTenant(updatedEntity);
   }

--- a/src/main/java/com/vi/tenantservice/api/model/TenantAdminAllowedPermissionTogglesSettings.java
+++ b/src/main/java/com/vi/tenantservice/api/model/TenantAdminAllowedPermissionTogglesSettings.java
@@ -13,6 +13,7 @@ public class TenantAdminAllowedPermissionTogglesSettings {
   Boolean appearance;
   Boolean anonymousChat;
   Boolean calls;
+  Boolean groupChat;
   Boolean supervision;
   Boolean supervisionAnonymousChats;
   Boolean supervisionOneOnOneChats;

--- a/src/main/java/com/vi/tenantservice/api/service/TenantService.java
+++ b/src/main/java/com/vi/tenantservice/api/service/TenantService.java
@@ -13,7 +13,9 @@ import java.io.File;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -89,6 +91,21 @@ public class TenantService {
     overrideSubdomainIfNeededForSingleDomainMultitenancy(tenantEntity);
     tenantEntity.setUpdateDate(LocalDateTime.now(ZoneOffset.UTC));
     return tenantRepository.save(tenantEntity);
+  }
+
+  public void updateTenantSettingsBatch(Map<Long, String> settingsByTenantId) {
+    if (settingsByTenantId == null || settingsByTenantId.isEmpty()) {
+      return;
+    }
+    LocalDateTime updateDate = LocalDateTime.now(ZoneOffset.UTC);
+    List<TenantEntity> tenants =
+        tenantRepository.findAllByIdIn(new ArrayList<>(settingsByTenantId.keySet()));
+    tenants.forEach(
+        tenant -> {
+          tenant.setSettings(settingsByTenantId.get(tenant.getId()));
+          tenant.setUpdateDate(updateDate);
+        });
+    tenantRepository.saveAll(tenants);
   }
 
   private void validateTenant(TenantEntity tenantEntity) {

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -9,25 +9,31 @@ logging.level.org.keycloak.adapters=DEBUG
 
 # Keycloak
 # Use Kubernetes DNS names, e.g., http://keycloak.caritas.svc.cluster.local:8080
-keycloak.auth-server-url=http://10.43.158.217:8080
+keycloak.auth-server-url=https://auth.oriso.org
 keycloak.realm=online-beratung
 keycloak.bearer-only=true
-spring.security.oauth2.resourceserver.jwt.issuer-uri=http://10.43.158.217:8080/realms/online-beratung
-spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://10.43.158.217:8080/realms/online-beratung/protocol/openid-connect/certs
+spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.oriso.org/realms/online-beratung
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=https://auth.oriso.org/realms/online-beratung/protocol/openid-connect/certs
 
 # MariaDB
 # Use Kubernetes DNS names, e.g., jdbc:mariadb://10.43.34.188:3306/tenantservice
 # NOT hardcoded IPs like jdbc:mariadb://10.43.34.188:3306/tenantservice
-spring.datasource.url=jdbc:mariadb://10.43.34.188:3306/tenantservice
-spring.datasource.username=tenantservice
-spring.datasource.password=tenantservice
+spring.datasource.url=jdbc:mariadb://178.105.141.133:32493/tenantservice
+spring.datasource.username=root
+spring.datasource.password=admin123!
 
 # Liquibase
 spring.liquibase.enabled=false
+spring.liquibase.change-log=classpath:db/changelog/tenantservice-local-master.xml
 # Database already exists, skip Liquibase migration
 
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=false
 server.port = 8081
 feature.multitenancy.with.single.domain.enabled=false
 keycloak.ssl-required=none
+
+consulting.type.service.api.url=https://api.oriso.org/service
+user.service.api.url=https://api.oriso.org/service
+spring.datasource.hikari.maximum-pool-size=2
+spring.datasource.hikari.minimum-idle=1

--- a/src/test/java/com/vi/tenantservice/api/facade/TenantAdminControlsCascadeServiceTest.java
+++ b/src/test/java/com/vi/tenantservice/api/facade/TenantAdminControlsCascadeServiceTest.java
@@ -1,0 +1,212 @@
+package com.vi.tenantservice.api.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.vi.tenantservice.api.converter.TenantConverter;
+import com.vi.tenantservice.api.model.MultilingualTenantDTO;
+import com.vi.tenantservice.api.model.Settings;
+import com.vi.tenantservice.api.model.TenantAdminAllowedPermissionToggles;
+import com.vi.tenantservice.api.model.TenantAdminAllowedPermissionTogglesSettings;
+import com.vi.tenantservice.api.model.TenantAdminControls;
+import com.vi.tenantservice.api.model.TenantAdminControlsSettings;
+import com.vi.tenantservice.api.model.TenantEntity;
+import com.vi.tenantservice.api.model.TenantSettings;
+import com.vi.tenantservice.api.service.TenantService;
+import com.vi.tenantservice.api.util.JsonConverter;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TenantAdminControlsCascadeServiceTest {
+
+  private static final Long PLATFORM_TENANT_ID = 1L;
+  private static final Long OTHER_TENANT_ID = 2L;
+
+  @Mock private TenantConverter tenantConverter;
+  @Mock private TenantService tenantService;
+
+  @InjectMocks private TenantAdminControlsCascadeService tenantAdminControlsCascadeService;
+
+  @Test
+  void
+      preserveTenantAdminControlsUnlessPlatformTenant_Should_restoreExistingControls_When_tenantIsNotPlatformTenant() {
+    MultilingualTenantDTO tenantDTO = tenantWithAllowedPermissionToggles(false);
+    TenantEntity existingTenant = existingTenantWithAllowedPermissionToggles(OTHER_TENANT_ID, true);
+
+    TenantAdminControls restoredControls =
+        new TenantAdminControls()
+            .allowedPermissionToggles(new TenantAdminAllowedPermissionToggles().appearance(true));
+    when(tenantConverter.toTenantAdminControls(any())).thenReturn(restoredControls);
+
+    tenantAdminControlsCascadeService.preserveTenantAdminControlsUnlessPlatformTenant(
+        tenantDTO, existingTenant);
+
+    assertThat(tenantDTO.getSettings().getTenantAdminControls()).isEqualTo(restoredControls);
+  }
+
+  @Test
+  void
+      preserveTenantAdminControlsUnlessPlatformTenant_Should_notModifyDto_When_tenantIsPlatformTenant() {
+    MultilingualTenantDTO tenantDTO = tenantWithAllowedPermissionToggles(false);
+    TenantEntity existingTenant =
+        existingTenantWithAllowedPermissionToggles(PLATFORM_TENANT_ID, true);
+
+    tenantAdminControlsCascadeService.preserveTenantAdminControlsUnlessPlatformTenant(
+        tenantDTO, existingTenant);
+
+    verify(tenantConverter, never()).toTenantAdminControls(any());
+  }
+
+  @Test
+  void
+      cascadeTenantAdminControlsIfPlatformTenant_Should_notCascade_When_tenantIsNotPlatformTenant() {
+    MultilingualTenantDTO tenantDTO = tenantWithAllowedPermissionToggles(false);
+    TenantEntity existingTenant = existingTenantWithAllowedPermissionToggles(OTHER_TENANT_ID, true);
+
+    tenantAdminControlsCascadeService.cascadeTenantAdminControlsIfPlatformTenant(
+        tenantDTO, OTHER_TENANT_ID, existingTenant.getSettings());
+
+    verify(tenantService, never()).getAllTenants();
+  }
+
+  @Test
+  void
+      cascadeTenantAdminControlsIfPlatformTenant_Should_notCascade_When_tenantAdminControlsDidNotChange() {
+    MultilingualTenantDTO tenantDTO = tenantWithAllowedPermissionToggles(false);
+    TenantEntity existingTenant =
+        existingTenantWithAllowedPermissionToggles(PLATFORM_TENANT_ID, false);
+
+    when(tenantConverter.toTenantAdminControlsSettings(any()))
+        .thenReturn(
+            TenantAdminControlsSettings.builder()
+                .allowedPermissionToggles(
+                    TenantAdminAllowedPermissionTogglesSettings.builder().appearance(false).build())
+                .build());
+
+    tenantAdminControlsCascadeService.cascadeTenantAdminControlsIfPlatformTenant(
+        tenantDTO, PLATFORM_TENANT_ID, existingTenant.getSettings());
+
+    verify(tenantService, never()).getAllTenants();
+  }
+
+  @Test
+  void
+      cascadeTenantAdminControlsIfPlatformTenant_Should_cascade_When_entityWasMutatedButPreviousSettingsDiffer() {
+    MultilingualTenantDTO tenantDTO = tenantWithAllowedPermissionToggles(false);
+    String previousSettingsJson =
+        JsonConverter.convertToJson(
+            TenantSettings.builder()
+                .tenantAdminControls(
+                    TenantAdminControlsSettings.builder()
+                        .allowedPermissionToggles(
+                            TenantAdminAllowedPermissionTogglesSettings.builder()
+                                .appearance(true)
+                                .build())
+                        .build())
+                .build());
+    TenantEntity mutatedTenant =
+        existingTenantWithAllowedPermissionToggles(PLATFORM_TENANT_ID, false);
+    TenantEntity otherTenant = otherTenantWithSettings();
+
+    when(tenantConverter.toTenantAdminControlsSettings(any()))
+        .thenReturn(
+            TenantAdminControlsSettings.builder()
+                .allowedPermissionToggles(
+                    TenantAdminAllowedPermissionTogglesSettings.builder().appearance(false).build())
+                .build());
+    when(tenantService.getAllTenants()).thenReturn(List.of(mutatedTenant, otherTenant));
+
+    tenantAdminControlsCascadeService.cascadeTenantAdminControlsIfPlatformTenant(
+        tenantDTO, PLATFORM_TENANT_ID, previousSettingsJson);
+
+    verify(tenantService).updateTenantSettingsBatch(anyMap());
+  }
+
+  @Test
+  void
+      cascadeTenantAdminControlsIfPlatformTenant_Should_cascadeToOtherTenants_When_platformTenant() {
+    MultilingualTenantDTO tenantDTO = tenantWithAllowedPermissionToggles(false);
+    TenantEntity existingTenant =
+        existingTenantWithAllowedPermissionToggles(PLATFORM_TENANT_ID, true);
+    TenantEntity otherTenant = otherTenantWithSettings();
+
+    when(tenantConverter.toTenantAdminControlsSettings(any()))
+        .thenReturn(
+            TenantAdminControlsSettings.builder()
+                .permissionsPageEnabled(true)
+                .allowedPermissionToggles(
+                    TenantAdminAllowedPermissionTogglesSettings.builder().appearance(false).build())
+                .build());
+    when(tenantService.getAllTenants()).thenReturn(List.of(existingTenant, otherTenant));
+
+    tenantAdminControlsCascadeService.cascadeTenantAdminControlsIfPlatformTenant(
+        tenantDTO, PLATFORM_TENANT_ID, existingTenant.getSettings());
+
+    verify(tenantService)
+        .updateTenantSettingsBatch(
+            argThat(
+                settingsByTenantId ->
+                    settingsByTenantId.size() == 1
+                        && settingsByTenantId.containsKey(otherTenant.getId())
+                        && settingsByTenantId
+                            .get(otherTenant.getId())
+                            .contains("\"appearance\":false")));
+  }
+
+  private MultilingualTenantDTO tenantWithAllowedPermissionToggles(boolean appearance) {
+    return new MultilingualTenantDTO()
+        .settings(
+            new Settings()
+                .tenantAdminControls(
+                    new TenantAdminControls()
+                        .allowedPermissionToggles(
+                            new TenantAdminAllowedPermissionToggles().appearance(appearance))));
+  }
+
+  private TenantEntity existingTenantWithAllowedPermissionToggles(
+      Long tenantId, boolean appearance) {
+    TenantEntity tenantEntity = new TenantEntity();
+    tenantEntity.setId(tenantId);
+    tenantEntity.setSettings(
+        JsonConverter.convertToJson(
+            TenantSettings.builder()
+                .tenantAdminControls(
+                    TenantAdminControlsSettings.builder()
+                        .allowedPermissionToggles(
+                            TenantAdminAllowedPermissionTogglesSettings.builder()
+                                .appearance(appearance)
+                                .build())
+                        .build())
+                .build()));
+    return tenantEntity;
+  }
+
+  private TenantEntity otherTenantWithSettings() {
+    TenantEntity tenantEntity = new TenantEntity();
+    tenantEntity.setId(OTHER_TENANT_ID);
+    tenantEntity.setSettings(
+        JsonConverter.convertToJson(
+            TenantSettings.builder()
+                .tenantAdminControls(
+                    TenantAdminControlsSettings.builder()
+                        .permissionsPageEnabled(true)
+                        .allowedPermissionToggles(
+                            TenantAdminAllowedPermissionTogglesSettings.builder()
+                                .appearance(true)
+                                .build())
+                        .build())
+                .featureTopicsEnabled(true)
+                .build()));
+    return tenantEntity;
+  }
+}

--- a/src/test/java/com/vi/tenantservice/api/facade/TenantServiceFacadeTest.java
+++ b/src/test/java/com/vi/tenantservice/api/facade/TenantServiceFacadeTest.java
@@ -104,6 +104,8 @@ class TenantServiceFacadeTest {
   @Mock
   private TenantFacadeDependentSettingsOverrideService tenantFacadeDependentSettingsOverrideService;
 
+  @Mock private TenantAdminControlsCascadeService tenantAdminControlsCascadeService;
+
   @Mock private SingleDomainTenantOverrideService singleDomainTenantOverrideService;
 
   @InjectMocks private TenantServiceFacade tenantServiceFacade;

--- a/src/test/java/com/vi/tenantservice/api/service/TenantServiceTest.java
+++ b/src/test/java/com/vi/tenantservice/api/service/TenantServiceTest.java
@@ -2,6 +2,7 @@ package com.vi.tenantservice.api.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -13,6 +14,7 @@ import com.vi.tenantservice.api.service.consultingtype.ApplicationSettingsServic
 import com.vi.tenantservice.applicationsettingsservice.generated.web.model.ApplicationSettingsDTO;
 import com.vi.tenantservice.applicationsettingsservice.generated.web.model.ApplicationSettingsDTOMainTenantSubdomainForSingleDomainMultitenancy;
 import java.time.LocalDateTime;
+import java.util.Map;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -178,6 +180,30 @@ class TenantServiceTest {
                 .mainTenantSubdomainForSingleDomainMultitenancy(
                     new ApplicationSettingsDTOMainTenantSubdomainForSingleDomainMultitenancy()
                         .value(subdomain)));
+  }
+
+  @Test
+  void updateTenantSettingsBatch_Should_SaveSettingsWithoutSubdomainValidation() {
+    TenantEntity tenantEntity = new TenantEntity();
+    tenantEntity.setId(2L);
+    tenantEntity.setSubdomain("duplicate-subdomain");
+    when(tenantRepository.findAllByIdIn(java.util.List.of(2L)))
+        .thenReturn(java.util.List.of(tenantEntity));
+
+    tenantService.updateTenantSettingsBatch(Map.of(2L, "{\"tenantAdminControls\":{}}"));
+
+    verify(tenantRepository).findAllByIdIn(java.util.List.of(2L));
+    verify(tenantRepository).saveAll(java.util.List.of(tenantEntity));
+    verify(tenantRepository, never()).findBySubdomain(org.mockito.ArgumentMatchers.any());
+    assertThat(tenantEntity.getSettings()).isEqualTo("{\"tenantAdminControls\":{}}");
+    assertThat(tenantEntity.getUpdateDate()).isNotNull();
+  }
+
+  @Test
+  void updateTenantSettingsBatch_Should_DoNothing_When_settingsMapIsEmpty() {
+    tenantService.updateTenantSettingsBatch(Map.of());
+
+    verifyNoMoreInteractions(tenantRepository);
   }
 
   @Test


### PR DESCRIPTION
## Bug Fix: Platform tenantAdminControls cascade and update restrictions

#### Related Issue: OpenResilienceInitiative/ORISO-Admin#107

## Summary
- Fixed tenantAdminControls sync so only updates to platform tenant (id 1) cascade to all tenants, while other tenant updates cannot change tenantAdminControls.

## Changes Made

- Added TenantAdminControlsCascadeService to cascade controls only when updated tenant id is 1
- Restored existing tenantAdminControls on PUT for all tenants except id 1
- Added updateTenantSettingsBatch in TenantService to update settings JSON without subdomain validation
- Wired cascade into TenantServiceFacade update flow with previous-settings snapshot for change detection
- Added groupChat to TenantAdminAllowedPermissionToggles in OpenAPI and TenantConverter
- Added unit tests for cascade service, batch settings update, and facade integration

## Testing

- Ran TenantAdminControlsCascadeServiceTest
- Ran TenantServiceTest (updateTenantSettingsBatch)
- Ran TenantServiceFacadeTest
- Verified PUT /tenantadmin/1 cascades tenantAdminControls to other tenants
- Verified PUT /tenantadmin/{otherId} does not change tenantAdminControls