### PR TITLE
Sanitary Integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <release.train.version>2022.0.5</release.train.version>
+        <sentry.version>8.43.2</sentry.version>
 
     </properties>
     <dependencyManagement>
@@ -115,6 +116,16 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-zipkin</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry-spring-boot-starter-jakarta</artifactId>
+            <version>${sentry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry-logback</artifactId>
+            <version>${sentry.version}</version>
         </dependency>
 
         <!-- Spring actuator  -->

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,6 +7,15 @@ logging.level.org.springframework.security=INFO
 logging.level.com.vi.tenantservice=DEBUG
 logging.level.org.springframework.web.servlet.DispatcherServlet=DEBUG
 
+# ---------------- Sentry ----------------
+sentry.dsn=${SENTRY_DSN:}
+sentry.environment=${SENTRY_ENVIRONMENT:dev}
+sentry.release=${SENTRY_RELEASE:oriso-tenantservice@local}
+sentry.traces-sample-rate=${SENTRY_TRACES_SAMPLE_RATE:0.0}
+sentry.send-default-pii=${SENTRY_SEND_DEFAULT_PII:false}
+sentry.logging.minimum-event-level=${SENTRY_LOGGING_MINIMUM_EVENT_LEVEL:warn}
+sentry.logging.minimum-breadcrumb-level=${SENTRY_LOGGING_MINIMUM_BREADCRUMB_LEVEL:info}
+
 spring.main.allow-bean-definition-overriding=true
 
 # Keycloak


### PR DESCRIPTION
## Summary
- Add Sentry Spring Boot 3 Jakarta starter to capture TenantService application exceptions.
- Add Sentry Logback integration so warning/error logs can be sent to Sentry.
- Configure Sentry through environment-backed properties for DSN, environment, release, PII, tracing, and log thresholds.

## Validation
- `./mvnw -DskipTests dependency:tree -Dincludes=io.sentry`

## Deployment Notes
- Create a Sentry project for `oriso-tenantservice` and set its DSN as `SENTRY_DSN` in the deployment.
- Set `SENTRY_RELEASE` to the deployed image tag or git SHA.
- Optional: adjust `SENTRY_LOGGING_MINIMUM_EVENT_LEVEL` and `SENTRY_LOGGING_MINIMUM_BREADCRUMB_LEVEL` if warnings get noisy.
