### PR TITLE
fix: remove jdwp debug agent from tenant service dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:17-jre
 VOLUME ["/tmp","/log"]
-EXPOSE 8080
+EXPOSE 8081
 ARG JAR_FILE
-ENV JAVA_UPPER_VERSION=eclipse-temurin:21-jre
+ENV JAVA_UPPER_VERSION=eclipse-temurin:17-jre
 COPY ./target/TenantService.jar app.jar
-ENTRYPOINT ["java","-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005","--enable-preview","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-XX:MaxRAMPercentage=75","-jar","/app.jar"]


### PR DESCRIPTION
## What
- Removed `-agentlib:jdwp=...` from Docker ENTRYPOINT — port 5005 was open with `server=y`, allowing unauthenticated remote code execution
- Removed `--enable-preview` Java flag (experimental APIs in production)
- Fixed `EXPOSE` port: was `8080`, TenantService actually binds on `8081`
- Fixed `ENV JAVA_UPPER_VERSION` label: was `eclipse-temurin:21-jre`, now matches `FROM eclipse-temurin:17-jre`
- Added `-XX:MaxRAMPercentage=75` for consistent memory management across all services

## Why
Closes #15 — JDWP debug agent left enabled in the production Docker image allows unauthenticated remote code execution on port 5005 for any network-accessible pod.

## Test
- [ ] `docker inspect <new-image> --format='{{json .Config.Entrypoint}}'` — confirm no `jdwp` in output
- [ ] After K8s deploy: `nc -zv <pod-ip> 5005` should timeout (port closed)