### PR TITLE
TS-C06 redact sensitive SMTP config from public tenant endpoints

### DIFF
--- a/src/main/java/com/vi/tenantservice/api/config/RestrictedPublicTenantJacksonConfig.java
+++ b/src/main/java/com/vi/tenantservice/api/config/RestrictedPublicTenantJacksonConfig.java
@@ -1,0 +1,24 @@
+package com.vi.tenantservice.api.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.vi.tenantservice.api.model.Settings;
+import com.vi.tenantservice.api.model.SmtpConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RestrictedPublicTenantJacksonConfig {
+
+  @Bean
+  public Module restrictedPublicTenantModule() {
+    SimpleModule module = new SimpleModule();
+    module.setMixInAnnotation(Settings.class, NonNullMixin.class);
+    module.setMixInAnnotation(SmtpConfig.class, NonNullMixin.class);
+    return module;
+  }
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private abstract static class NonNullMixin {}
+}

--- a/src/main/java/com/vi/tenantservice/api/converter/TenantConverter.java
+++ b/src/main/java/com/vi/tenantservice/api/converter/TenantConverter.java
@@ -534,7 +534,27 @@ public class TenantConverter {
         .content(toContentDTO(tenant, lang))
         .theming(toThemingDTO(tenant))
         .subdomain(tenant.getSubdomain())
-        .settings(getSettings(tenant));
+        .settings(getRestrictedPublicSettings(tenant));
+  }
+
+  private Settings getRestrictedPublicSettings(TenantEntity tenant) {
+    Settings settings = getSettings(tenant);
+    settings.setFeatureToolsOICDToken(null);
+    settings.setSmtp(toPublicSmtpConfig(settings.getSmtp()));
+    return settings;
+  }
+
+  private SmtpConfig toPublicSmtpConfig(SmtpConfig smtpConfig) {
+    if (smtpConfig == null) {
+      return null;
+    }
+    return new SmtpConfig()
+        .enabled(smtpConfig.getEnabled())
+        .host(smtpConfig.getHost())
+        .port(smtpConfig.getPort())
+        .secure(smtpConfig.getSecure())
+        .from(smtpConfig.getFrom())
+        .emailThemeColor(smtpConfig.getEmailThemeColor());
   }
 
   public BasicTenantLicensingDTO toBasicLicensingTenantDTO(TenantEntity tenant) {

--- a/src/test/java/com/vi/tenantservice/api/config/RestrictedPublicTenantJacksonConfigTest.java
+++ b/src/test/java/com/vi/tenantservice/api/config/RestrictedPublicTenantJacksonConfigTest.java
@@ -1,0 +1,42 @@
+package com.vi.tenantservice.api.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vi.tenantservice.api.model.Settings;
+import com.vi.tenantservice.api.model.SmtpConfig;
+import org.junit.jupiter.api.Test;
+
+class RestrictedPublicTenantJacksonConfigTest {
+
+  private final RestrictedPublicTenantJacksonConfig config =
+      new RestrictedPublicTenantJacksonConfig();
+
+  @Test
+  void restrictedPublicTenantModule_should_omitNullSensitiveFields() throws Exception {
+    Settings settings = new Settings();
+    settings.setFeatureToolsOICDToken(null);
+    settings.setSmtp(
+        new SmtpConfig()
+            .enabled(true)
+            .host("smtp.example.org")
+            .port(587)
+            .secure(false)
+            .username(null)
+            .password(null)
+            .from("notifications@example.org")
+            .emailThemeColor("#123456"));
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.registerModule(config.restrictedPublicTenantModule());
+
+    String json = objectMapper.writeValueAsString(settings);
+
+    assertThat(json).contains("\"smtp\"");
+    assertThat(json).contains("\"host\":\"smtp.example.org\"");
+    assertThat(json).contains("\"from\":\"notifications@example.org\"");
+    assertThat(json).doesNotContain("featureToolsOICDToken");
+    assertThat(json).doesNotContain("\"username\"");
+    assertThat(json).doesNotContain("\"password\"");
+  }
+}

--- a/src/test/java/com/vi/tenantservice/api/converter/TenantConverterTest.java
+++ b/src/test/java/com/vi/tenantservice/api/converter/TenantConverterTest.java
@@ -9,6 +9,7 @@ import com.vi.tenantservice.api.model.MultilingualTenantDTO;
 import com.vi.tenantservice.api.model.NoAgencyContextDTO;
 import com.vi.tenantservice.api.model.RestrictedTenantDTO;
 import com.vi.tenantservice.api.model.Settings;
+import com.vi.tenantservice.api.model.SmtpConfig;
 import com.vi.tenantservice.api.model.TenantAdminAllowedPermissionToggles;
 import com.vi.tenantservice.api.model.TenantAdminControls;
 import com.vi.tenantservice.api.model.TenantDTO;
@@ -98,9 +99,52 @@ class TenantConverterTest {
     assertThat(restrictedTenantDTO.getSubdomain()).isEqualTo(tenantDTO.getSubdomain());
     assertThat(restrictedTenantDTO.getTheming()).isEqualTo(tenantDTO.getTheming());
     assertContentIsProperlyConverted(tenantDTO, restrictedTenantDTO);
-    assertCoreSettingsAreConverted(tenantDTO.getSettings(), restrictedTenantDTO.getSettings());
+    assertRestrictedPublicSettingsAreConverted(
+        tenantDTO.getSettings(), restrictedTenantDTO.getSettings());
     Mockito.verify(templateRenderer).renderTemplate(Mockito.anyString(), Mockito.anyMap());
     assertThat(restrictedTenantDTO.getContent().getRenderedPrivacy()).isEqualTo("renderedPrivacy");
+  }
+
+  @Test
+  void toRestrictedTenantDTO_should_redactSensitivePublicSettings() {
+    // given
+    MultilingualTenantDTO tenantDTO =
+        new MultilingualTenantTestDataBuilder()
+            .tenantDTO()
+            .withContent()
+            .withTheming()
+            .withLicensing()
+            .withSettings()
+            .build();
+    tenantDTO
+        .getSettings()
+        .featureToolsOICDToken("secret-oidc-token")
+        .smtp(
+            new SmtpConfig()
+                .enabled(true)
+                .host("smtp.example.org")
+                .port(587)
+                .secure(false)
+                .username("smtp-user")
+                .password("smtp-pass")
+                .from("notifications@example.org")
+                .emailThemeColor("#123456"));
+
+    TenantEntity entity = tenantConverter.toEntity(tenantDTO);
+
+    // when
+    RestrictedTenantDTO restrictedTenantDTO =
+        tenantConverter.toRestrictedTenantDTO(entity, TenantConverter.DE);
+
+    // then
+    assertThat(restrictedTenantDTO.getSettings().getFeatureToolsOICDToken()).isNull();
+    assertThat(restrictedTenantDTO.getSettings().getSmtp()).isNotNull();
+    assertThat(restrictedTenantDTO.getSettings().getSmtp().getHost()).isEqualTo("smtp.example.org");
+    assertThat(restrictedTenantDTO.getSettings().getSmtp().getPort()).isEqualTo(587);
+    assertThat(restrictedTenantDTO.getSettings().getSmtp().getFrom())
+        .isEqualTo("notifications@example.org");
+    assertThat(restrictedTenantDTO.getSettings().getSmtp().getUsername()).isNull();
+    assertThat(restrictedTenantDTO.getSettings().getSmtp().getPassword()).isNull();
   }
 
   @Test
@@ -179,6 +223,35 @@ class TenantConverterTest {
         .isTrue();
   }
 
+  @Test
+  void toDTO_should_preserveSensitiveSettingsForNonPublicDtos() {
+    // given
+    MultilingualTenantDTO tenantDTO =
+        new MultilingualTenantTestDataBuilder().tenantDTO().withSettings().build();
+    tenantDTO
+        .getSettings()
+        .featureToolsOICDToken("secret-oidc-token")
+        .smtp(
+            new SmtpConfig()
+                .enabled(true)
+                .host("smtp.example.org")
+                .port(587)
+                .secure(false)
+                .username("smtp-user")
+                .password("smtp-pass")
+                .from("notifications@example.org")
+                .emailThemeColor("#123456"));
+
+    // when
+    TenantDTO converted = tenantConverter.toDTO(tenantConverter.toEntity(tenantDTO), "de");
+
+    // then
+    assertThat(converted.getSettings().getFeatureToolsOICDToken()).isEqualTo("secret-oidc-token");
+    assertThat(converted.getSettings().getSmtp()).isNotNull();
+    assertThat(converted.getSettings().getSmtp().getUsername()).isEqualTo("smtp-user");
+    assertThat(converted.getSettings().getSmtp().getPassword()).isEqualTo("smtp-pass");
+  }
+
   private static void assertContentIsProperlyConverted(
       MultilingualTenantDTO tenantDTO, RestrictedTenantDTO restrictedTenantDTO) {
     assertThat(restrictedTenantDTO.getContent().getClaim())
@@ -213,6 +286,46 @@ class TenantConverterTest {
     assertThat(actual.getFeatureCentralDataProtectionTemplateEnabled())
         .isEqualTo(expected.getFeatureCentralDataProtectionTemplateEnabled());
     assertThat(actual.getTenantAdminControls()).isEqualTo(expected.getTenantAdminControls());
+  }
+
+  private static void assertRestrictedPublicSettingsAreConverted(
+      Settings expected, Settings actual) {
+    assertThat(actual.getFeatureStatisticsEnabled())
+        .isEqualTo(expected.getFeatureStatisticsEnabled());
+    assertThat(actual.getFeatureTopicsEnabled()).isEqualTo(expected.getFeatureTopicsEnabled());
+    assertThat(actual.getTopicsInRegistrationEnabled())
+        .isEqualTo(expected.getTopicsInRegistrationEnabled());
+    assertThat(actual.getFeatureDemographicsEnabled())
+        .isEqualTo(expected.getFeatureDemographicsEnabled());
+    assertThat(actual.getFeatureAppointmentsEnabled())
+        .isEqualTo(expected.getFeatureAppointmentsEnabled());
+    assertThat(actual.getFeatureGroupChatV2Enabled())
+        .isEqualTo(expected.getFeatureGroupChatV2Enabled());
+    assertThat(actual.getFeatureToolsEnabled()).isEqualTo(expected.getFeatureToolsEnabled());
+    assertThat(actual.getFeatureAttachmentUploadDisabled())
+        .isEqualTo(expected.getFeatureAttachmentUploadDisabled());
+    assertThat(actual.getActiveLanguages()).isEqualTo(expected.getActiveLanguages());
+    assertThat(actual.getShowAskerProfile()).isEqualTo(expected.getShowAskerProfile());
+    assertThat(actual.getIsVideoCallAllowed()).isEqualTo(expected.getIsVideoCallAllowed());
+    assertThat(actual.getFeatureCentralDataProtectionTemplateEnabled())
+        .isEqualTo(expected.getFeatureCentralDataProtectionTemplateEnabled());
+    assertThat(actual.getTenantAdminControls()).isEqualTo(expected.getTenantAdminControls());
+    assertThat(actual.getFeatureToolsOICDToken()).isNull();
+    if (expected.getSmtp() == null) {
+      assertThat(actual.getSmtp()).isNull();
+      return;
+    }
+
+    assertThat(actual.getSmtp()).isNotNull();
+    assertThat(actual.getSmtp().getEnabled()).isEqualTo(expected.getSmtp().getEnabled());
+    assertThat(actual.getSmtp().getHost()).isEqualTo(expected.getSmtp().getHost());
+    assertThat(actual.getSmtp().getPort()).isEqualTo(expected.getSmtp().getPort());
+    assertThat(actual.getSmtp().getSecure()).isEqualTo(expected.getSmtp().getSecure());
+    assertThat(actual.getSmtp().getFrom()).isEqualTo(expected.getSmtp().getFrom());
+    assertThat(actual.getSmtp().getEmailThemeColor())
+        .isEqualTo(expected.getSmtp().getEmailThemeColor());
+    assertThat(actual.getSmtp().getUsername()).isNull();
+    assertThat(actual.getSmtp().getPassword()).isNull();
   }
 
   private static String getGermanTranslation(Map<String, String> translations) {


### PR DESCRIPTION
## Summary

Fixes TS-C06: public tenant endpoints were exposing sensitive SMTP configuration.

Changes:
- redacted sensitive SMTP fields from restricted public tenant responses
- removed `featureToolsOICDToken` from public tenant responses
- kept only safe SMTP fields needed by public flows:
  - `enabled`
  - `host`
  - `port`
  - `secure`
  - `from`
  - `emailThemeColor`
- added Jackson config so null-sensitive fields are omitted from serialized public JSON
- added regression tests for converter redaction and public JSON serialization

No API contract changes were made for internal/admin tenant DTOs.

## Manual Verification

Verified locally through public endpoints:

- `GET /tenant/public/id/1`
- `GET /tenant/public/happylife`

Result:
- response still returns expected public tenant data
- `settings.smtp.username` is not exposed
- `settings.smtp.password` is not exposed
- `settings.featureToolsOICDToken` is not exposed

## Tests

```bash
.\mvnw.cmd "-Dtest=TenantConverterTest,RestrictedPublicTenantJacksonConfigTest" test
.\mvnw.cmd "-DskipTests" spotless:check
.\mvnw.cmd "-DskipTests" "-Dspotles
s.check.skip=true" compile

Attached public endpoint response after the fix — SMTP username/password and featureToolsOICDToken are no longer exposed.
[JSON.txt](https://github.com/user-attachments/files/29017800/JSON.txt)
