### PR TITLE
fix: restore TenantService preview runtime flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ EXPOSE 8081
 ARG JAR_FILE
 ENV JAVA_UPPER_VERSION=eclipse-temurin:17-jre
 COPY ./target/TenantService.jar app.jar
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-XX:MaxRAMPercentage=75","-jar","/app.jar"]
+ENTRYPOINT ["java","--enable-preview","-Djava.security.egd=file:/dev/./urandom","-XX:MaxRAMPercentage=75","-jar","/app.jar"]


### PR DESCRIPTION
## Summary
- add `--enable-preview` back to the TenantService Dockerfile runtime command
- keep JDWP removed from the image
- keep the corrected Java 17 metadata and `EXPOSE 8081` from the previous JDWP cleanup

## Reason
TenantService is still compiled with Java 17 preview features. Without the runtime flag the pod crashes with:

```text
UnsupportedClassVersionError: Preview features are not enabled
Try running with --enable-preview
```

This PR restores the required runtime flag while keeping port 5005/JDWP disabled.

## Verification
- `rg -n "jdwp|agentlib|5005" Dockerfile || true` returns no matches
- Dockerfile starts Java with `--enable-preview` and no debug agent

## Follow-up
Long term, remove preview usage from TenantService code and `pom.xml`, then this runtime flag can be removed safely.