### PR TITLE
Fix: TS-H01 replaces ~250 lines of duplicated settingsJson.contains() string-matching

### DIFF
--- a/src/main/java/com/vi/tenantservice/api/converter/TenantConverter.java
+++ b/src/main/java/com/vi/tenantservice/api/converter/TenantConverter.java
@@ -76,64 +76,57 @@ public class TenantConverter {
 
   private TenantSettings toEntitySettings(Settings settings) {
     return TenantSettings.builder()
-        .topicsInRegistrationEnabled(nullAsFalse(settings.getTopicsInRegistrationEnabled()))
-        .featureDemographicsEnabled(nullAsFalse(settings.getFeatureDemographicsEnabled()))
-        .featureTopicsEnabled(nullAsFalse(settings.getFeatureTopicsEnabled()))
-        .featureAppointmentsEnabled(nullAsFalse(settings.getFeatureAppointmentsEnabled()))
-        .featureStatisticsEnabled(nullAsFalse(settings.getFeatureStatisticsEnabled()))
-        .featureGroupChatV2Enabled(nullAsFalse(settings.getFeatureGroupChatV2Enabled()))
-        .featureToolsEnabled(nullAsFalse(settings.getFeatureToolsEnabled()))
-        .featureAnonymousChatEnabled(nullAsTrue(settings.getFeatureAnonymousChatEnabled()))
-        .featureCallsEnabled(nullAsTrue(settings.getFeatureCallsEnabled()))
-        .featureSupervisionEnabled(nullAsTrue(settings.getFeatureSupervisionEnabled()))
+        .topicsInRegistrationEnabled(settings.getTopicsInRegistrationEnabled())
+        .featureDemographicsEnabled(settings.getFeatureDemographicsEnabled())
+        .featureTopicsEnabled(settings.getFeatureTopicsEnabled())
+        .featureAppointmentsEnabled(settings.getFeatureAppointmentsEnabled())
+        .featureStatisticsEnabled(settings.getFeatureStatisticsEnabled())
+        .featureGroupChatV2Enabled(settings.getFeatureGroupChatV2Enabled())
+        .featureToolsEnabled(settings.getFeatureToolsEnabled())
+        .featureAnonymousChatEnabled(settings.getFeatureAnonymousChatEnabled())
+        .featureCallsEnabled(settings.getFeatureCallsEnabled())
+        .featureSupervisionEnabled(settings.getFeatureSupervisionEnabled())
         .featureSupervisionAnonymousChatsEnabled(
-            nullAsTrue(settings.getFeatureSupervisionAnonymousChatsEnabled()))
+            settings.getFeatureSupervisionAnonymousChatsEnabled())
         .featureSupervisionOneOnOneChatsEnabled(
-            nullAsTrue(settings.getFeatureSupervisionOneOnOneChatsEnabled()))
-        .featureAudioCallsEnabled(nullAsTrue(settings.getFeatureAudioCallsEnabled()))
+            settings.getFeatureSupervisionOneOnOneChatsEnabled())
+        .featureAudioCallsEnabled(settings.getFeatureAudioCallsEnabled())
         .featureAudioCallsAnonymousChatsEnabled(
-            nullAsTrue(settings.getFeatureAudioCallsAnonymousChatsEnabled()))
-        .featureAudioCallsOneOnOneChatsEnabled(
-            nullAsTrue(settings.getFeatureAudioCallsOneOnOneChatsEnabled()))
-        .featureAudioCallsGroupChatsEnabled(
-            nullAsTrue(settings.getFeatureAudioCallsGroupChatsEnabled()))
+            settings.getFeatureAudioCallsAnonymousChatsEnabled())
+        .featureAudioCallsOneOnOneChatsEnabled(settings.getFeatureAudioCallsOneOnOneChatsEnabled())
+        .featureAudioCallsGroupChatsEnabled(settings.getFeatureAudioCallsGroupChatsEnabled())
         .featureAudioCallsSupervisionChatsEnabled(
-            nullAsTrue(settings.getFeatureAudioCallsSupervisionChatsEnabled()))
-        .featureVideoCallsEnabled(nullAsTrue(settings.getFeatureVideoCallsEnabled()))
+            settings.getFeatureAudioCallsSupervisionChatsEnabled())
+        .featureVideoCallsEnabled(settings.getFeatureVideoCallsEnabled())
         .featureVideoCallsAnonymousChatsEnabled(
-            nullAsTrue(settings.getFeatureVideoCallsAnonymousChatsEnabled()))
-        .featureVideoCallsOneOnOneChatsEnabled(
-            nullAsTrue(settings.getFeatureVideoCallsOneOnOneChatsEnabled()))
-        .featureVideoCallsGroupChatsEnabled(
-            nullAsTrue(settings.getFeatureVideoCallsGroupChatsEnabled()))
+            settings.getFeatureVideoCallsAnonymousChatsEnabled())
+        .featureVideoCallsOneOnOneChatsEnabled(settings.getFeatureVideoCallsOneOnOneChatsEnabled())
+        .featureVideoCallsGroupChatsEnabled(settings.getFeatureVideoCallsGroupChatsEnabled())
         .featureVideoCallsSupervisionChatsEnabled(
-            nullAsTrue(settings.getFeatureVideoCallsSupervisionChatsEnabled()))
-        .featureThreadsEnabled(nullAsTrue(settings.getFeatureThreadsEnabled()))
-        .featureThreadsAnonymousChatsEnabled(
-            nullAsTrue(settings.getFeatureThreadsAnonymousChatsEnabled()))
-        .featureThreadsGroupChatsEnabled(nullAsTrue(settings.getFeatureThreadsGroupChatsEnabled()))
-        .featureThreadsOneOnOneEnabled(nullAsTrue(settings.getFeatureThreadsOneOnOneEnabled()))
-        .featureThreadsSupervisionChatsEnabled(
-            nullAsTrue(settings.getFeatureThreadsSupervisionChatsEnabled()))
-        .featureVoiceMessagesEnabled(nullAsTrue(settings.getFeatureVoiceMessagesEnabled()))
+            settings.getFeatureVideoCallsSupervisionChatsEnabled())
+        .featureThreadsEnabled(settings.getFeatureThreadsEnabled())
+        .featureThreadsAnonymousChatsEnabled(settings.getFeatureThreadsAnonymousChatsEnabled())
+        .featureThreadsGroupChatsEnabled(settings.getFeatureThreadsGroupChatsEnabled())
+        .featureThreadsOneOnOneEnabled(settings.getFeatureThreadsOneOnOneEnabled())
+        .featureThreadsSupervisionChatsEnabled(settings.getFeatureThreadsSupervisionChatsEnabled())
+        .featureVoiceMessagesEnabled(settings.getFeatureVoiceMessagesEnabled())
         .featureVoiceMessagesAnonymousChatsEnabled(
-            nullAsTrue(settings.getFeatureVoiceMessagesAnonymousChatsEnabled()))
+            settings.getFeatureVoiceMessagesAnonymousChatsEnabled())
         .featureVoiceMessagesOneOnOneChatsEnabled(
-            nullAsTrue(settings.getFeatureVoiceMessagesOneOnOneChatsEnabled()))
-        .featureVoiceMessagesGroupChatsEnabled(
-            nullAsTrue(settings.getFeatureVoiceMessagesGroupChatsEnabled()))
+            settings.getFeatureVoiceMessagesOneOnOneChatsEnabled())
+        .featureVoiceMessagesGroupChatsEnabled(settings.getFeatureVoiceMessagesGroupChatsEnabled())
         .featureVoiceMessagesSupervisionChatsEnabled(
-            nullAsTrue(settings.getFeatureVoiceMessagesSupervisionChatsEnabled()))
+            settings.getFeatureVoiceMessagesSupervisionChatsEnabled())
         .featureSystemNotificationEmailsEnabled(
-            nullAsFalse(settings.getFeatureSystemNotificationEmailsEnabled()))
+            settings.getFeatureSystemNotificationEmailsEnabled())
         .smtp(toTenantSmtpSettings(settings.getSmtp()))
         .featureToolsOIDCToken(settings.getFeatureToolsOICDToken())
-        .featureAttachmentUploadDisabled(nullAsFalse(settings.getFeatureAttachmentUploadDisabled()))
+        .featureAttachmentUploadDisabled(settings.getFeatureAttachmentUploadDisabled())
         .activeLanguages(nullAsGerman(settings.getActiveLanguages()))
-        .isVideoCallAllowed(nullAsFalse(settings.getIsVideoCallAllowed()))
-        .showAskerProfile(nullAsFalse(settings.getShowAskerProfile()))
+        .isVideoCallAllowed(settings.getIsVideoCallAllowed())
+        .showAskerProfile(settings.getShowAskerProfile())
         .featureCentralDataProtectionTemplateEnabled(
-            nullAsFalse(settings.getFeatureCentralDataProtectionTemplateEnabled()))
+            settings.getFeatureCentralDataProtectionTemplateEnabled())
         .tenantAdminControls(toTenantAdminControlsSettings(settings.getTenantAdminControls()))
         .build();
   }
@@ -224,154 +217,63 @@ public class TenantConverter {
   }
 
   private Settings getSettingsIfNotNull(String settingsJson) {
-    TenantSettings tenantSettings = JsonConverter.convertFromJson(settingsJson);
-    final boolean anonymousChatEnabled =
-        settingsJson != null && settingsJson.contains("\"featureAnonymousChatEnabled\"")
-            ? tenantSettings.isFeatureAnonymousChatEnabled()
-            : true;
-    final boolean callsEnabled =
-        settingsJson != null && settingsJson.contains("\"featureCallsEnabled\"")
-            ? tenantSettings.isFeatureCallsEnabled()
-            : true;
-    final boolean supervisionEnabled =
-        settingsJson != null && settingsJson.contains("\"featureSupervisionEnabled\"")
-            ? tenantSettings.isFeatureSupervisionEnabled()
-            : true;
-    final boolean supervisionAnonymousChatsEnabled =
-        settingsJson != null && settingsJson.contains("\"featureSupervisionAnonymousChatsEnabled\"")
-            ? tenantSettings.isFeatureSupervisionAnonymousChatsEnabled()
-            : true;
-    final boolean supervisionOneOnOneChatsEnabled =
-        settingsJson != null && settingsJson.contains("\"featureSupervisionOneOnOneChatsEnabled\"")
-            ? tenantSettings.isFeatureSupervisionOneOnOneChatsEnabled()
-            : true;
-    final boolean audioCallsEnabled =
-        settingsJson != null && settingsJson.contains("\"featureAudioCallsEnabled\"")
-            ? tenantSettings.isFeatureAudioCallsEnabled()
-            : true;
-    final boolean audioCallsAnonymousChatsEnabled =
-        settingsJson != null && settingsJson.contains("\"featureAudioCallsAnonymousChatsEnabled\"")
-            ? tenantSettings.isFeatureAudioCallsAnonymousChatsEnabled()
-            : true;
-    final boolean audioCallsOneOnOneChatsEnabled =
-        settingsJson != null && settingsJson.contains("\"featureAudioCallsOneOnOneChatsEnabled\"")
-            ? tenantSettings.isFeatureAudioCallsOneOnOneChatsEnabled()
-            : true;
-    final boolean audioCallsGroupChatsEnabled =
-        settingsJson != null && settingsJson.contains("\"featureAudioCallsGroupChatsEnabled\"")
-            ? tenantSettings.isFeatureAudioCallsGroupChatsEnabled()
-            : true;
-    final boolean audioCallsSupervisionChatsEnabled =
-        settingsJson != null
-                && settingsJson.contains("\"featureAudioCallsSupervisionChatsEnabled\"")
-            ? tenantSettings.isFeatureAudioCallsSupervisionChatsEnabled()
-            : true;
-    final boolean videoCallsEnabled =
-        settingsJson != null && settingsJson.contains("\"featureVideoCallsEnabled\"")
-            ? tenantSettings.isFeatureVideoCallsEnabled()
-            : true;
-    final boolean videoCallsAnonymousChatsEnabled =
-        settingsJson != null && settingsJson.contains("\"featureVideoCallsAnonymousChatsEnabled\"")
-            ? tenantSettings.isFeatureVideoCallsAnonymousChatsEnabled()
-            : true;
-    final boolean videoCallsOneOnOneChatsEnabled =
-        settingsJson != null && settingsJson.contains("\"featureVideoCallsOneOnOneChatsEnabled\"")
-            ? tenantSettings.isFeatureVideoCallsOneOnOneChatsEnabled()
-            : true;
-    final boolean videoCallsGroupChatsEnabled =
-        settingsJson != null && settingsJson.contains("\"featureVideoCallsGroupChatsEnabled\"")
-            ? tenantSettings.isFeatureVideoCallsGroupChatsEnabled()
-            : true;
-    final boolean videoCallsSupervisionChatsEnabled =
-        settingsJson != null
-                && settingsJson.contains("\"featureVideoCallsSupervisionChatsEnabled\"")
-            ? tenantSettings.isFeatureVideoCallsSupervisionChatsEnabled()
-            : true;
-    final boolean threadsEnabled =
-        settingsJson != null && settingsJson.contains("\"featureThreadsEnabled\"")
-            ? tenantSettings.isFeatureThreadsEnabled()
-            : true;
-    final boolean threadsAnonymousChatsEnabled =
-        settingsJson != null && settingsJson.contains("\"featureThreadsAnonymousChatsEnabled\"")
-            ? tenantSettings.isFeatureThreadsAnonymousChatsEnabled()
-            : true;
-    final boolean threadsGroupChatsEnabled =
-        settingsJson != null && settingsJson.contains("\"featureThreadsGroupChatsEnabled\"")
-            ? tenantSettings.isFeatureThreadsGroupChatsEnabled()
-            : true;
-    final boolean threadsOneOnOneEnabled =
-        settingsJson != null && settingsJson.contains("\"featureThreadsOneOnOneEnabled\"")
-            ? tenantSettings.isFeatureThreadsOneOnOneEnabled()
-            : true;
-    final boolean threadsSupervisionChatsEnabled =
-        settingsJson != null && settingsJson.contains("\"featureThreadsSupervisionChatsEnabled\"")
-            ? tenantSettings.isFeatureThreadsSupervisionChatsEnabled()
-            : true;
-    final boolean voiceMessagesEnabled =
-        settingsJson != null && settingsJson.contains("\"featureVoiceMessagesEnabled\"")
-            ? tenantSettings.isFeatureVoiceMessagesEnabled()
-            : true;
-    final boolean voiceMessagesAnonymousChatsEnabled =
-        settingsJson != null
-                && settingsJson.contains("\"featureVoiceMessagesAnonymousChatsEnabled\"")
-            ? tenantSettings.isFeatureVoiceMessagesAnonymousChatsEnabled()
-            : true;
-    final boolean voiceMessagesOneOnOneChatsEnabled =
-        settingsJson != null
-                && settingsJson.contains("\"featureVoiceMessagesOneOnOneChatsEnabled\"")
-            ? tenantSettings.isFeatureVoiceMessagesOneOnOneChatsEnabled()
-            : true;
-    final boolean voiceMessagesGroupChatsEnabled =
-        settingsJson != null && settingsJson.contains("\"featureVoiceMessagesGroupChatsEnabled\"")
-            ? tenantSettings.isFeatureVoiceMessagesGroupChatsEnabled()
-            : true;
-    final boolean voiceMessagesSupervisionChatsEnabled =
-        settingsJson != null
-                && settingsJson.contains("\"featureVoiceMessagesSupervisionChatsEnabled\"")
-            ? tenantSettings.isFeatureVoiceMessagesSupervisionChatsEnabled()
-            : true;
+    TenantSettings tenantSettings = JsonConverter.convertFromJson(settingsJson).applyDefaults();
     return new Settings()
-        .topicsInRegistrationEnabled(tenantSettings.isTopicsInRegistrationEnabled())
-        .featureDemographicsEnabled(tenantSettings.isFeatureDemographicsEnabled())
-        .featureTopicsEnabled(tenantSettings.isFeatureTopicsEnabled())
-        .featureAppointmentsEnabled(tenantSettings.isFeatureAppointmentsEnabled())
-        .featureStatisticsEnabled(tenantSettings.isFeatureStatisticsEnabled())
-        .featureGroupChatV2Enabled(tenantSettings.isFeatureGroupChatV2Enabled())
+        .topicsInRegistrationEnabled(tenantSettings.getTopicsInRegistrationEnabled())
+        .featureDemographicsEnabled(tenantSettings.getFeatureDemographicsEnabled())
+        .featureTopicsEnabled(tenantSettings.getFeatureTopicsEnabled())
+        .featureAppointmentsEnabled(tenantSettings.getFeatureAppointmentsEnabled())
+        .featureStatisticsEnabled(tenantSettings.getFeatureStatisticsEnabled())
+        .featureGroupChatV2Enabled(tenantSettings.getFeatureGroupChatV2Enabled())
         .featureToolsOICDToken(tenantSettings.getFeatureToolsOIDCToken())
-        .featureToolsEnabled(tenantSettings.isFeatureToolsEnabled())
-        .featureAnonymousChatEnabled(anonymousChatEnabled)
-        .featureCallsEnabled(callsEnabled)
-        .featureSupervisionEnabled(supervisionEnabled)
-        .featureSupervisionAnonymousChatsEnabled(supervisionAnonymousChatsEnabled)
-        .featureSupervisionOneOnOneChatsEnabled(supervisionOneOnOneChatsEnabled)
-        .featureAudioCallsEnabled(audioCallsEnabled)
-        .featureAudioCallsAnonymousChatsEnabled(audioCallsAnonymousChatsEnabled)
-        .featureAudioCallsOneOnOneChatsEnabled(audioCallsOneOnOneChatsEnabled)
-        .featureAudioCallsGroupChatsEnabled(audioCallsGroupChatsEnabled)
-        .featureAudioCallsSupervisionChatsEnabled(audioCallsSupervisionChatsEnabled)
-        .featureVideoCallsEnabled(videoCallsEnabled)
-        .featureVideoCallsAnonymousChatsEnabled(videoCallsAnonymousChatsEnabled)
-        .featureVideoCallsOneOnOneChatsEnabled(videoCallsOneOnOneChatsEnabled)
-        .featureVideoCallsGroupChatsEnabled(videoCallsGroupChatsEnabled)
-        .featureVideoCallsSupervisionChatsEnabled(videoCallsSupervisionChatsEnabled)
-        .featureThreadsEnabled(threadsEnabled)
-        .featureThreadsAnonymousChatsEnabled(threadsAnonymousChatsEnabled)
-        .featureThreadsGroupChatsEnabled(threadsGroupChatsEnabled)
-        .featureThreadsOneOnOneEnabled(threadsOneOnOneEnabled)
-        .featureThreadsSupervisionChatsEnabled(threadsSupervisionChatsEnabled)
-        .featureVoiceMessagesEnabled(voiceMessagesEnabled)
-        .featureVoiceMessagesAnonymousChatsEnabled(voiceMessagesAnonymousChatsEnabled)
-        .featureVoiceMessagesOneOnOneChatsEnabled(voiceMessagesOneOnOneChatsEnabled)
-        .featureVoiceMessagesGroupChatsEnabled(voiceMessagesGroupChatsEnabled)
-        .featureVoiceMessagesSupervisionChatsEnabled(voiceMessagesSupervisionChatsEnabled)
+        .featureToolsEnabled(tenantSettings.getFeatureToolsEnabled())
+        .featureAnonymousChatEnabled(tenantSettings.getFeatureAnonymousChatEnabled())
+        .featureCallsEnabled(tenantSettings.getFeatureCallsEnabled())
+        .featureSupervisionEnabled(tenantSettings.getFeatureSupervisionEnabled())
+        .featureSupervisionAnonymousChatsEnabled(
+            tenantSettings.getFeatureSupervisionAnonymousChatsEnabled())
+        .featureSupervisionOneOnOneChatsEnabled(
+            tenantSettings.getFeatureSupervisionOneOnOneChatsEnabled())
+        .featureAudioCallsEnabled(tenantSettings.getFeatureAudioCallsEnabled())
+        .featureAudioCallsAnonymousChatsEnabled(
+            tenantSettings.getFeatureAudioCallsAnonymousChatsEnabled())
+        .featureAudioCallsOneOnOneChatsEnabled(
+            tenantSettings.getFeatureAudioCallsOneOnOneChatsEnabled())
+        .featureAudioCallsGroupChatsEnabled(tenantSettings.getFeatureAudioCallsGroupChatsEnabled())
+        .featureAudioCallsSupervisionChatsEnabled(
+            tenantSettings.getFeatureAudioCallsSupervisionChatsEnabled())
+        .featureVideoCallsEnabled(tenantSettings.getFeatureVideoCallsEnabled())
+        .featureVideoCallsAnonymousChatsEnabled(
+            tenantSettings.getFeatureVideoCallsAnonymousChatsEnabled())
+        .featureVideoCallsOneOnOneChatsEnabled(
+            tenantSettings.getFeatureVideoCallsOneOnOneChatsEnabled())
+        .featureVideoCallsGroupChatsEnabled(tenantSettings.getFeatureVideoCallsGroupChatsEnabled())
+        .featureVideoCallsSupervisionChatsEnabled(
+            tenantSettings.getFeatureVideoCallsSupervisionChatsEnabled())
+        .featureThreadsEnabled(tenantSettings.getFeatureThreadsEnabled())
+        .featureThreadsAnonymousChatsEnabled(
+            tenantSettings.getFeatureThreadsAnonymousChatsEnabled())
+        .featureThreadsGroupChatsEnabled(tenantSettings.getFeatureThreadsGroupChatsEnabled())
+        .featureThreadsOneOnOneEnabled(tenantSettings.getFeatureThreadsOneOnOneEnabled())
+        .featureThreadsSupervisionChatsEnabled(
+            tenantSettings.getFeatureThreadsSupervisionChatsEnabled())
+        .featureVoiceMessagesEnabled(tenantSettings.getFeatureVoiceMessagesEnabled())
+        .featureVoiceMessagesAnonymousChatsEnabled(
+            tenantSettings.getFeatureVoiceMessagesAnonymousChatsEnabled())
+        .featureVoiceMessagesOneOnOneChatsEnabled(
+            tenantSettings.getFeatureVoiceMessagesOneOnOneChatsEnabled())
+        .featureVoiceMessagesGroupChatsEnabled(
+            tenantSettings.getFeatureVoiceMessagesGroupChatsEnabled())
+        .featureVoiceMessagesSupervisionChatsEnabled(
+            tenantSettings.getFeatureVoiceMessagesSupervisionChatsEnabled())
         .featureSystemNotificationEmailsEnabled(
-            tenantSettings.isFeatureSystemNotificationEmailsEnabled())
+            tenantSettings.getFeatureSystemNotificationEmailsEnabled())
         .smtp(toSmtpConfig(tenantSettings.getSmtp()))
-        .featureAttachmentUploadDisabled(tenantSettings.isFeatureAttachmentUploadDisabled())
-        .isVideoCallAllowed(tenantSettings.isVideoCallAllowed())
-        .showAskerProfile(tenantSettings.isShowAskerProfile())
+        .featureAttachmentUploadDisabled(tenantSettings.getFeatureAttachmentUploadDisabled())
+        .isVideoCallAllowed(tenantSettings.getIsVideoCallAllowed())
+        .showAskerProfile(tenantSettings.getShowAskerProfile())
         .featureCentralDataProtectionTemplateEnabled(
-            tenantSettings.isFeatureCentralDataProtectionTemplateEnabled())
+            tenantSettings.getFeatureCentralDataProtectionTemplateEnabled())
         .tenantAdminControls(toTenantAdminControls(tenantSettings.getTenantAdminControls()))
         .activeLanguages(nullAsGerman(tenantSettings.getActiveLanguages()));
   }

--- a/src/main/java/com/vi/tenantservice/api/facade/TenantFacadeChangeDetectionService.java
+++ b/src/main/java/com/vi/tenantservice/api/facade/TenantFacadeChangeDetectionService.java
@@ -65,142 +65,142 @@ public class TenantFacadeChangeDetectionService {
     List<TenantSetting> resultList = Lists.newArrayList();
     if (isChanged(
         inputSettings.getFeatureDemographicsEnabled(),
-        existingSettingsToCompare.isFeatureDemographicsEnabled())) {
+        existingSettingsToCompare.getFeatureDemographicsEnabled())) {
       resultList.add(TenantSetting.FEATURE_DEMOGRAPHICS_ENABLED);
     }
     if (isChanged(
         inputSettings.getFeatureTopicsEnabled(),
-        existingSettingsToCompare.isFeatureTopicsEnabled())) {
+        existingSettingsToCompare.getFeatureTopicsEnabled())) {
       resultList.add(TenantSetting.FEATURE_TOPICS_ENABLED);
     }
     if (isChanged(
         inputSettings.getTopicsInRegistrationEnabled(),
-        existingSettingsToCompare.isTopicsInRegistrationEnabled())) {
+        existingSettingsToCompare.getTopicsInRegistrationEnabled())) {
       resultList.add(TenantSetting.ENABLE_TOPICS_IN_REGISTRATION);
     }
     if (isChanged(
         inputSettings.getFeatureStatisticsEnabled(),
-        existingSettingsToCompare.isFeatureStatisticsEnabled())) {
+        existingSettingsToCompare.getFeatureStatisticsEnabled())) {
       resultList.add(TenantSetting.FEATURE_STATISTICS_ENABLED);
     }
     if (isChanged(
         inputSettings.getFeatureAppointmentsEnabled(),
-        existingSettingsToCompare.isFeatureAppointmentsEnabled())) {
+        existingSettingsToCompare.getFeatureAppointmentsEnabled())) {
       resultList.add(TenantSetting.FEATURE_APPOINTMENTS_ENABLED);
     }
     if (isChanged(
         inputSettings.getFeatureGroupChatV2Enabled(),
-        existingSettingsToCompare.isFeatureGroupChatV2Enabled())) {
+        existingSettingsToCompare.getFeatureGroupChatV2Enabled())) {
       resultList.add(TenantSetting.FEATURE_GROUP_CHAT_V2_ENABLED);
     }
     if (isChanged(
         inputSettings.getFeatureToolsEnabled(),
-        existingSettingsToCompare.isFeatureToolsEnabled())) {
+        existingSettingsToCompare.getFeatureToolsEnabled())) {
       resultList.add(TenantSetting.FEATURE_TOOLS_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureAnonymousChatEnabled())
-        != existingSettingsToCompare.isFeatureAnonymousChatEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureAnonymousChatEnabled())) {
       resultList.add(TenantSetting.FEATURE_ANONYMOUS_CHAT_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureCallsEnabled())
-        != existingSettingsToCompare.isFeatureCallsEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureCallsEnabled())) {
       resultList.add(TenantSetting.FEATURE_CALLS_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureSupervisionEnabled())
-        != existingSettingsToCompare.isFeatureSupervisionEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureSupervisionEnabled())) {
       resultList.add(TenantSetting.FEATURE_SUPERVISION_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureSupervisionAnonymousChatsEnabled())
-        != existingSettingsToCompare.isFeatureSupervisionAnonymousChatsEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureSupervisionAnonymousChatsEnabled())) {
       resultList.add(TenantSetting.FEATURE_SUPERVISION_ANONYMOUS_CHATS_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureSupervisionOneOnOneChatsEnabled())
-        != existingSettingsToCompare.isFeatureSupervisionOneOnOneChatsEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureSupervisionOneOnOneChatsEnabled())) {
       resultList.add(TenantSetting.FEATURE_SUPERVISION_ONE_ON_ONE_CHATS_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureAudioCallsEnabled())
-        != existingSettingsToCompare.isFeatureAudioCallsEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureAudioCallsEnabled())) {
       resultList.add(TenantSetting.FEATURE_AUDIO_CALLS_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureAudioCallsAnonymousChatsEnabled())
-        != existingSettingsToCompare.isFeatureAudioCallsAnonymousChatsEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureAudioCallsAnonymousChatsEnabled())) {
       resultList.add(TenantSetting.FEATURE_AUDIO_CALLS_ANONYMOUS_CHATS_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureAudioCallsOneOnOneChatsEnabled())
-        != existingSettingsToCompare.isFeatureAudioCallsOneOnOneChatsEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureAudioCallsOneOnOneChatsEnabled())) {
       resultList.add(TenantSetting.FEATURE_AUDIO_CALLS_ONE_ON_ONE_CHATS_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureAudioCallsGroupChatsEnabled())
-        != existingSettingsToCompare.isFeatureAudioCallsGroupChatsEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureAudioCallsGroupChatsEnabled())) {
       resultList.add(TenantSetting.FEATURE_AUDIO_CALLS_GROUP_CHATS_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureAudioCallsSupervisionChatsEnabled())
-        != existingSettingsToCompare.isFeatureAudioCallsSupervisionChatsEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureAudioCallsSupervisionChatsEnabled())) {
       resultList.add(TenantSetting.FEATURE_AUDIO_CALLS_SUPERVISION_CHATS_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureVideoCallsEnabled())
-        != existingSettingsToCompare.isFeatureVideoCallsEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureVideoCallsEnabled())) {
       resultList.add(TenantSetting.FEATURE_VIDEO_CALLS_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureVideoCallsAnonymousChatsEnabled())
-        != existingSettingsToCompare.isFeatureVideoCallsAnonymousChatsEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureVideoCallsAnonymousChatsEnabled())) {
       resultList.add(TenantSetting.FEATURE_VIDEO_CALLS_ANONYMOUS_CHATS_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureVideoCallsOneOnOneChatsEnabled())
-        != existingSettingsToCompare.isFeatureVideoCallsOneOnOneChatsEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureVideoCallsOneOnOneChatsEnabled())) {
       resultList.add(TenantSetting.FEATURE_VIDEO_CALLS_ONE_ON_ONE_CHATS_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureVideoCallsGroupChatsEnabled())
-        != existingSettingsToCompare.isFeatureVideoCallsGroupChatsEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureVideoCallsGroupChatsEnabled())) {
       resultList.add(TenantSetting.FEATURE_VIDEO_CALLS_GROUP_CHATS_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureVideoCallsSupervisionChatsEnabled())
-        != existingSettingsToCompare.isFeatureVideoCallsSupervisionChatsEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureVideoCallsSupervisionChatsEnabled())) {
       resultList.add(TenantSetting.FEATURE_VIDEO_CALLS_SUPERVISION_CHATS_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureThreadsEnabled())
-        != existingSettingsToCompare.isFeatureThreadsEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureThreadsEnabled())) {
       resultList.add(TenantSetting.FEATURE_THREADS_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureThreadsAnonymousChatsEnabled())
-        != existingSettingsToCompare.isFeatureThreadsAnonymousChatsEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureThreadsAnonymousChatsEnabled())) {
       resultList.add(TenantSetting.FEATURE_THREADS_ANONYMOUS_CHATS_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureThreadsGroupChatsEnabled())
-        != existingSettingsToCompare.isFeatureThreadsGroupChatsEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureThreadsGroupChatsEnabled())) {
       resultList.add(TenantSetting.FEATURE_THREADS_GROUP_CHATS_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureThreadsOneOnOneEnabled())
-        != existingSettingsToCompare.isFeatureThreadsOneOnOneEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureThreadsOneOnOneEnabled())) {
       resultList.add(TenantSetting.FEATURE_THREADS_ONE_ON_ONE_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureThreadsSupervisionChatsEnabled())
-        != existingSettingsToCompare.isFeatureThreadsSupervisionChatsEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureThreadsSupervisionChatsEnabled())) {
       resultList.add(TenantSetting.FEATURE_THREADS_SUPERVISION_CHATS_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureVoiceMessagesEnabled())
-        != existingSettingsToCompare.isFeatureVoiceMessagesEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureVoiceMessagesEnabled())) {
       resultList.add(TenantSetting.FEATURE_VOICE_MESSAGES_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureVoiceMessagesAnonymousChatsEnabled())
-        != existingSettingsToCompare.isFeatureVoiceMessagesAnonymousChatsEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureVoiceMessagesAnonymousChatsEnabled())) {
       resultList.add(TenantSetting.FEATURE_VOICE_MESSAGES_ANONYMOUS_CHATS_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureVoiceMessagesOneOnOneChatsEnabled())
-        != existingSettingsToCompare.isFeatureVoiceMessagesOneOnOneChatsEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureVoiceMessagesOneOnOneChatsEnabled())) {
       resultList.add(TenantSetting.FEATURE_VOICE_MESSAGES_ONE_ON_ONE_CHATS_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureVoiceMessagesGroupChatsEnabled())
-        != existingSettingsToCompare.isFeatureVoiceMessagesGroupChatsEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureVoiceMessagesGroupChatsEnabled())) {
       resultList.add(TenantSetting.FEATURE_VOICE_MESSAGES_GROUP_CHATS_ENABLED);
     }
     if (nullAsTrue(inputSettings.getFeatureVoiceMessagesSupervisionChatsEnabled())
-        != existingSettingsToCompare.isFeatureVoiceMessagesSupervisionChatsEnabled()) {
+        != nullAsTrue(existingSettingsToCompare.getFeatureVoiceMessagesSupervisionChatsEnabled())) {
       resultList.add(TenantSetting.FEATURE_VOICE_MESSAGES_SUPERVISION_CHATS_ENABLED);
     }
     if (isChanged(
         inputSettings.getFeatureAttachmentUploadDisabled(),
-        existingSettingsToCompare.isFeatureAttachmentUploadDisabled())) {
+        existingSettingsToCompare.getFeatureAttachmentUploadDisabled())) {
       resultList.add(TenantSetting.FEATURE_ATTACHMENT_UPLOAD_DISABLED);
     }
     if (isChangedIgnoringOrder(
@@ -214,8 +214,8 @@ public class TenantFacadeChangeDetectionService {
     return !StringUtils.equals(newContent, existingContent);
   }
 
-  private boolean isChanged(Boolean inputSettings, boolean existingSettingsToCompare) {
-    return nullAsFalse(inputSettings) != existingSettingsToCompare;
+  private boolean isChanged(Boolean inputSettings, Boolean existingSettingsToCompare) {
+    return nullAsFalse(inputSettings) != nullAsFalse(existingSettingsToCompare);
   }
 
   private boolean isChangedIgnoringOrder(
@@ -232,116 +232,10 @@ public class TenantFacadeChangeDetectionService {
   }
 
   private TenantSettings getExistingTenantSettings(TenantEntity existingTenant) {
-    TenantSettings existingSettingsToCompare;
     if (existingTenant.getSettings() == null) {
-      existingSettingsToCompare = new TenantSettings();
-      // Default should be enabled if missing completely.
-      existingSettingsToCompare.setFeatureAnonymousChatEnabled(true);
-      existingSettingsToCompare.setFeatureCallsEnabled(true);
-      existingSettingsToCompare.setFeatureSupervisionEnabled(true);
-      existingSettingsToCompare.setFeatureSupervisionAnonymousChatsEnabled(true);
-      existingSettingsToCompare.setFeatureSupervisionOneOnOneChatsEnabled(true);
-      existingSettingsToCompare.setFeatureAudioCallsEnabled(true);
-      existingSettingsToCompare.setFeatureAudioCallsAnonymousChatsEnabled(true);
-      existingSettingsToCompare.setFeatureAudioCallsOneOnOneChatsEnabled(true);
-      existingSettingsToCompare.setFeatureAudioCallsGroupChatsEnabled(true);
-      existingSettingsToCompare.setFeatureAudioCallsSupervisionChatsEnabled(true);
-      existingSettingsToCompare.setFeatureVideoCallsEnabled(true);
-      existingSettingsToCompare.setFeatureVideoCallsAnonymousChatsEnabled(true);
-      existingSettingsToCompare.setFeatureVideoCallsOneOnOneChatsEnabled(true);
-      existingSettingsToCompare.setFeatureVideoCallsGroupChatsEnabled(true);
-      existingSettingsToCompare.setFeatureVideoCallsSupervisionChatsEnabled(true);
-      existingSettingsToCompare.setFeatureThreadsEnabled(true);
-      existingSettingsToCompare.setFeatureThreadsAnonymousChatsEnabled(true);
-      existingSettingsToCompare.setFeatureThreadsGroupChatsEnabled(true);
-      existingSettingsToCompare.setFeatureThreadsOneOnOneEnabled(true);
-      existingSettingsToCompare.setFeatureThreadsSupervisionChatsEnabled(true);
-      existingSettingsToCompare.setFeatureVoiceMessagesEnabled(true);
-      existingSettingsToCompare.setFeatureVoiceMessagesAnonymousChatsEnabled(true);
-      existingSettingsToCompare.setFeatureVoiceMessagesOneOnOneChatsEnabled(true);
-      existingSettingsToCompare.setFeatureVoiceMessagesGroupChatsEnabled(true);
-      existingSettingsToCompare.setFeatureVoiceMessagesSupervisionChatsEnabled(true);
-    } else {
-      final String settingsJson = existingTenant.getSettings();
-      existingSettingsToCompare = JsonConverter.convertFromJson(settingsJson);
-      // Default should be enabled if the setting is not present in stored JSON (backward compat).
-      if (!settingsJson.contains("\"featureAnonymousChatEnabled\"")) {
-        existingSettingsToCompare.setFeatureAnonymousChatEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureCallsEnabled\"")) {
-        existingSettingsToCompare.setFeatureCallsEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureSupervisionEnabled\"")) {
-        existingSettingsToCompare.setFeatureSupervisionEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureSupervisionAnonymousChatsEnabled\"")) {
-        existingSettingsToCompare.setFeatureSupervisionAnonymousChatsEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureSupervisionOneOnOneChatsEnabled\"")) {
-        existingSettingsToCompare.setFeatureSupervisionOneOnOneChatsEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureAudioCallsEnabled\"")) {
-        existingSettingsToCompare.setFeatureAudioCallsEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureAudioCallsAnonymousChatsEnabled\"")) {
-        existingSettingsToCompare.setFeatureAudioCallsAnonymousChatsEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureAudioCallsOneOnOneChatsEnabled\"")) {
-        existingSettingsToCompare.setFeatureAudioCallsOneOnOneChatsEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureAudioCallsGroupChatsEnabled\"")) {
-        existingSettingsToCompare.setFeatureAudioCallsGroupChatsEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureAudioCallsSupervisionChatsEnabled\"")) {
-        existingSettingsToCompare.setFeatureAudioCallsSupervisionChatsEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureVideoCallsEnabled\"")) {
-        existingSettingsToCompare.setFeatureVideoCallsEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureVideoCallsAnonymousChatsEnabled\"")) {
-        existingSettingsToCompare.setFeatureVideoCallsAnonymousChatsEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureVideoCallsOneOnOneChatsEnabled\"")) {
-        existingSettingsToCompare.setFeatureVideoCallsOneOnOneChatsEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureVideoCallsGroupChatsEnabled\"")) {
-        existingSettingsToCompare.setFeatureVideoCallsGroupChatsEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureVideoCallsSupervisionChatsEnabled\"")) {
-        existingSettingsToCompare.setFeatureVideoCallsSupervisionChatsEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureThreadsEnabled\"")) {
-        existingSettingsToCompare.setFeatureThreadsEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureThreadsAnonymousChatsEnabled\"")) {
-        existingSettingsToCompare.setFeatureThreadsAnonymousChatsEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureThreadsGroupChatsEnabled\"")) {
-        existingSettingsToCompare.setFeatureThreadsGroupChatsEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureThreadsOneOnOneEnabled\"")) {
-        existingSettingsToCompare.setFeatureThreadsOneOnOneEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureThreadsSupervisionChatsEnabled\"")) {
-        existingSettingsToCompare.setFeatureThreadsSupervisionChatsEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureVoiceMessagesEnabled\"")) {
-        existingSettingsToCompare.setFeatureVoiceMessagesEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureVoiceMessagesAnonymousChatsEnabled\"")) {
-        existingSettingsToCompare.setFeatureVoiceMessagesAnonymousChatsEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureVoiceMessagesOneOnOneChatsEnabled\"")) {
-        existingSettingsToCompare.setFeatureVoiceMessagesOneOnOneChatsEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureVoiceMessagesGroupChatsEnabled\"")) {
-        existingSettingsToCompare.setFeatureVoiceMessagesGroupChatsEnabled(true);
-      }
-      if (!settingsJson.contains("\"featureVoiceMessagesSupervisionChatsEnabled\"")) {
-        existingSettingsToCompare.setFeatureVoiceMessagesSupervisionChatsEnabled(true);
-      }
+      return new TenantSettings().applyDefaults();
     }
-    return existingSettingsToCompare;
+    return JsonConverter.convertFromJson(existingTenant.getSettings()).applyDefaults();
   }
 
   boolean nullAsFalse(Boolean value) {

--- a/src/main/java/com/vi/tenantservice/api/model/TenantSettings.java
+++ b/src/main/java/com/vi/tenantservice/api/model/TenantSettings.java
@@ -1,6 +1,8 @@
 package com.vi.tenantservice.api.model;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,50 +14,240 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class TenantSettings {
 
-  boolean featureStatisticsEnabled;
-  boolean featureTopicsEnabled;
-  boolean topicsInRegistrationEnabled;
-  boolean featureDemographicsEnabled;
-  boolean featureAppointmentsEnabled;
-  boolean featureGroupChatV2Enabled;
-  boolean featureToolsEnabled;
-  boolean featureAnonymousChatEnabled;
-  boolean featureCallsEnabled;
-  boolean featureSupervisionEnabled;
-  boolean featureSupervisionAnonymousChatsEnabled;
-  boolean featureSupervisionOneOnOneChatsEnabled;
-  boolean featureAudioCallsEnabled;
-  boolean featureAudioCallsAnonymousChatsEnabled;
-  boolean featureAudioCallsOneOnOneChatsEnabled;
-  boolean featureAudioCallsGroupChatsEnabled;
-  boolean featureAudioCallsSupervisionChatsEnabled;
-  boolean featureVideoCallsEnabled;
-  boolean featureVideoCallsAnonymousChatsEnabled;
-  boolean featureVideoCallsOneOnOneChatsEnabled;
-  boolean featureVideoCallsGroupChatsEnabled;
-  boolean featureVideoCallsSupervisionChatsEnabled;
-  boolean featureThreadsEnabled;
-  boolean featureThreadsAnonymousChatsEnabled;
-  boolean featureThreadsGroupChatsEnabled;
-  boolean featureThreadsOneOnOneEnabled;
-  boolean featureThreadsSupervisionChatsEnabled;
-  boolean featureVoiceMessagesEnabled;
-  boolean featureVoiceMessagesAnonymousChatsEnabled;
-  boolean featureVoiceMessagesOneOnOneChatsEnabled;
-  boolean featureVoiceMessagesGroupChatsEnabled;
-  boolean featureVoiceMessagesSupervisionChatsEnabled;
-  boolean featureSystemNotificationEmailsEnabled;
+  Boolean featureStatisticsEnabled;
+  Boolean featureTopicsEnabled;
+  Boolean topicsInRegistrationEnabled;
+  Boolean featureDemographicsEnabled;
+  Boolean featureAppointmentsEnabled;
+  Boolean featureGroupChatV2Enabled;
+  Boolean featureToolsEnabled;
+  Boolean featureAnonymousChatEnabled;
+  Boolean featureCallsEnabled;
+  Boolean featureSupervisionEnabled;
+  Boolean featureSupervisionAnonymousChatsEnabled;
+  Boolean featureSupervisionOneOnOneChatsEnabled;
+  Boolean featureAudioCallsEnabled;
+  Boolean featureAudioCallsAnonymousChatsEnabled;
+  Boolean featureAudioCallsOneOnOneChatsEnabled;
+  Boolean featureAudioCallsGroupChatsEnabled;
+  Boolean featureAudioCallsSupervisionChatsEnabled;
+  Boolean featureVideoCallsEnabled;
+  Boolean featureVideoCallsAnonymousChatsEnabled;
+  Boolean featureVideoCallsOneOnOneChatsEnabled;
+  Boolean featureVideoCallsGroupChatsEnabled;
+  Boolean featureVideoCallsSupervisionChatsEnabled;
+  Boolean featureThreadsEnabled;
+  Boolean featureThreadsAnonymousChatsEnabled;
+  Boolean featureThreadsGroupChatsEnabled;
+  Boolean featureThreadsOneOnOneEnabled;
+  Boolean featureThreadsSupervisionChatsEnabled;
+  Boolean featureVoiceMessagesEnabled;
+  Boolean featureVoiceMessagesAnonymousChatsEnabled;
+  Boolean featureVoiceMessagesOneOnOneChatsEnabled;
+  Boolean featureVoiceMessagesGroupChatsEnabled;
+  Boolean featureVoiceMessagesSupervisionChatsEnabled;
+  Boolean featureSystemNotificationEmailsEnabled;
   TenantSmtpSettings smtp;
-  boolean featureAttachmentUploadDisabled;
-  boolean isVideoCallAllowed;
-  boolean showAskerProfile;
+  Boolean featureAttachmentUploadDisabled;
+  Boolean isVideoCallAllowed;
+  Boolean showAskerProfile;
 
   String featureToolsOIDCToken;
   List<String> activeLanguages;
 
-  boolean featureCentralDataProtectionEnabled;
+  Boolean featureCentralDataProtectionEnabled;
 
-  boolean featureCentralDataProtectionTemplateEnabled;
+  Boolean featureCentralDataProtectionTemplateEnabled;
 
   TenantAdminControlsSettings tenantAdminControls;
+
+  /**
+   * Documented defaults for boolean feature flags when a key is absent from stored JSON. Keyed by
+   * Jackson property / field name. Excludes {@code featureCentralDataProtectionEnabled} (orphan
+   * field, out of scope).
+   */
+  private static final Map<String, Boolean> BOOLEAN_FIELD_DEFAULTS =
+      Collections.unmodifiableMap(
+          Map.ofEntries(
+              Map.entry("featureStatisticsEnabled", false),
+              Map.entry("featureTopicsEnabled", false),
+              Map.entry("topicsInRegistrationEnabled", false),
+              Map.entry("featureDemographicsEnabled", false),
+              Map.entry("featureAppointmentsEnabled", false),
+              Map.entry("featureGroupChatV2Enabled", false),
+              Map.entry("featureToolsEnabled", false),
+              Map.entry("featureAnonymousChatEnabled", true),
+              Map.entry("featureCallsEnabled", true),
+              Map.entry("featureSupervisionEnabled", true),
+              Map.entry("featureSupervisionAnonymousChatsEnabled", true),
+              Map.entry("featureSupervisionOneOnOneChatsEnabled", true),
+              Map.entry("featureAudioCallsEnabled", true),
+              Map.entry("featureAudioCallsAnonymousChatsEnabled", true),
+              Map.entry("featureAudioCallsOneOnOneChatsEnabled", true),
+              Map.entry("featureAudioCallsGroupChatsEnabled", true),
+              Map.entry("featureAudioCallsSupervisionChatsEnabled", true),
+              Map.entry("featureVideoCallsEnabled", true),
+              Map.entry("featureVideoCallsAnonymousChatsEnabled", true),
+              Map.entry("featureVideoCallsOneOnOneChatsEnabled", true),
+              Map.entry("featureVideoCallsGroupChatsEnabled", true),
+              Map.entry("featureVideoCallsSupervisionChatsEnabled", true),
+              Map.entry("featureThreadsEnabled", true),
+              Map.entry("featureThreadsAnonymousChatsEnabled", true),
+              Map.entry("featureThreadsGroupChatsEnabled", true),
+              Map.entry("featureThreadsOneOnOneEnabled", true),
+              Map.entry("featureThreadsSupervisionChatsEnabled", true),
+              Map.entry("featureVoiceMessagesEnabled", true),
+              Map.entry("featureVoiceMessagesAnonymousChatsEnabled", true),
+              Map.entry("featureVoiceMessagesOneOnOneChatsEnabled", true),
+              Map.entry("featureVoiceMessagesGroupChatsEnabled", true),
+              Map.entry("featureVoiceMessagesSupervisionChatsEnabled", true),
+              Map.entry("featureSystemNotificationEmailsEnabled", false),
+              Map.entry("featureAttachmentUploadDisabled", false),
+              Map.entry("isVideoCallAllowed", false),
+              Map.entry("showAskerProfile", false),
+              Map.entry("featureCentralDataProtectionTemplateEnabled", false)));
+
+  public static Map<String, Boolean> getBooleanFieldDefaults() {
+    return BOOLEAN_FIELD_DEFAULTS;
+  }
+
+  /**
+   * Fills any null boolean wrapper field with its documented default. Does not touch non-boolean
+   * fields or {@code featureCentralDataProtectionEnabled}. Call after Jackson deserialization when
+   * absent keys must be distinguished from explicit {@code false}.
+   */
+  public TenantSettings applyDefaults() {
+    if (featureStatisticsEnabled == null) {
+      featureStatisticsEnabled = BOOLEAN_FIELD_DEFAULTS.get("featureStatisticsEnabled");
+    }
+    if (featureTopicsEnabled == null) {
+      featureTopicsEnabled = BOOLEAN_FIELD_DEFAULTS.get("featureTopicsEnabled");
+    }
+    if (topicsInRegistrationEnabled == null) {
+      topicsInRegistrationEnabled = BOOLEAN_FIELD_DEFAULTS.get("topicsInRegistrationEnabled");
+    }
+    if (featureDemographicsEnabled == null) {
+      featureDemographicsEnabled = BOOLEAN_FIELD_DEFAULTS.get("featureDemographicsEnabled");
+    }
+    if (featureAppointmentsEnabled == null) {
+      featureAppointmentsEnabled = BOOLEAN_FIELD_DEFAULTS.get("featureAppointmentsEnabled");
+    }
+    if (featureGroupChatV2Enabled == null) {
+      featureGroupChatV2Enabled = BOOLEAN_FIELD_DEFAULTS.get("featureGroupChatV2Enabled");
+    }
+    if (featureToolsEnabled == null) {
+      featureToolsEnabled = BOOLEAN_FIELD_DEFAULTS.get("featureToolsEnabled");
+    }
+    if (featureAnonymousChatEnabled == null) {
+      featureAnonymousChatEnabled = BOOLEAN_FIELD_DEFAULTS.get("featureAnonymousChatEnabled");
+    }
+    if (featureCallsEnabled == null) {
+      featureCallsEnabled = BOOLEAN_FIELD_DEFAULTS.get("featureCallsEnabled");
+    }
+    if (featureSupervisionEnabled == null) {
+      featureSupervisionEnabled = BOOLEAN_FIELD_DEFAULTS.get("featureSupervisionEnabled");
+    }
+    if (featureSupervisionAnonymousChatsEnabled == null) {
+      featureSupervisionAnonymousChatsEnabled =
+          BOOLEAN_FIELD_DEFAULTS.get("featureSupervisionAnonymousChatsEnabled");
+    }
+    if (featureSupervisionOneOnOneChatsEnabled == null) {
+      featureSupervisionOneOnOneChatsEnabled =
+          BOOLEAN_FIELD_DEFAULTS.get("featureSupervisionOneOnOneChatsEnabled");
+    }
+    if (featureAudioCallsEnabled == null) {
+      featureAudioCallsEnabled = BOOLEAN_FIELD_DEFAULTS.get("featureAudioCallsEnabled");
+    }
+    if (featureAudioCallsAnonymousChatsEnabled == null) {
+      featureAudioCallsAnonymousChatsEnabled =
+          BOOLEAN_FIELD_DEFAULTS.get("featureAudioCallsAnonymousChatsEnabled");
+    }
+    if (featureAudioCallsOneOnOneChatsEnabled == null) {
+      featureAudioCallsOneOnOneChatsEnabled =
+          BOOLEAN_FIELD_DEFAULTS.get("featureAudioCallsOneOnOneChatsEnabled");
+    }
+    if (featureAudioCallsGroupChatsEnabled == null) {
+      featureAudioCallsGroupChatsEnabled =
+          BOOLEAN_FIELD_DEFAULTS.get("featureAudioCallsGroupChatsEnabled");
+    }
+    if (featureAudioCallsSupervisionChatsEnabled == null) {
+      featureAudioCallsSupervisionChatsEnabled =
+          BOOLEAN_FIELD_DEFAULTS.get("featureAudioCallsSupervisionChatsEnabled");
+    }
+    if (featureVideoCallsEnabled == null) {
+      featureVideoCallsEnabled = BOOLEAN_FIELD_DEFAULTS.get("featureVideoCallsEnabled");
+    }
+    if (featureVideoCallsAnonymousChatsEnabled == null) {
+      featureVideoCallsAnonymousChatsEnabled =
+          BOOLEAN_FIELD_DEFAULTS.get("featureVideoCallsAnonymousChatsEnabled");
+    }
+    if (featureVideoCallsOneOnOneChatsEnabled == null) {
+      featureVideoCallsOneOnOneChatsEnabled =
+          BOOLEAN_FIELD_DEFAULTS.get("featureVideoCallsOneOnOneChatsEnabled");
+    }
+    if (featureVideoCallsGroupChatsEnabled == null) {
+      featureVideoCallsGroupChatsEnabled =
+          BOOLEAN_FIELD_DEFAULTS.get("featureVideoCallsGroupChatsEnabled");
+    }
+    if (featureVideoCallsSupervisionChatsEnabled == null) {
+      featureVideoCallsSupervisionChatsEnabled =
+          BOOLEAN_FIELD_DEFAULTS.get("featureVideoCallsSupervisionChatsEnabled");
+    }
+    if (featureThreadsEnabled == null) {
+      featureThreadsEnabled = BOOLEAN_FIELD_DEFAULTS.get("featureThreadsEnabled");
+    }
+    if (featureThreadsAnonymousChatsEnabled == null) {
+      featureThreadsAnonymousChatsEnabled =
+          BOOLEAN_FIELD_DEFAULTS.get("featureThreadsAnonymousChatsEnabled");
+    }
+    if (featureThreadsGroupChatsEnabled == null) {
+      featureThreadsGroupChatsEnabled =
+          BOOLEAN_FIELD_DEFAULTS.get("featureThreadsGroupChatsEnabled");
+    }
+    if (featureThreadsOneOnOneEnabled == null) {
+      featureThreadsOneOnOneEnabled = BOOLEAN_FIELD_DEFAULTS.get("featureThreadsOneOnOneEnabled");
+    }
+    if (featureThreadsSupervisionChatsEnabled == null) {
+      featureThreadsSupervisionChatsEnabled =
+          BOOLEAN_FIELD_DEFAULTS.get("featureThreadsSupervisionChatsEnabled");
+    }
+    if (featureVoiceMessagesEnabled == null) {
+      featureVoiceMessagesEnabled = BOOLEAN_FIELD_DEFAULTS.get("featureVoiceMessagesEnabled");
+    }
+    if (featureVoiceMessagesAnonymousChatsEnabled == null) {
+      featureVoiceMessagesAnonymousChatsEnabled =
+          BOOLEAN_FIELD_DEFAULTS.get("featureVoiceMessagesAnonymousChatsEnabled");
+    }
+    if (featureVoiceMessagesOneOnOneChatsEnabled == null) {
+      featureVoiceMessagesOneOnOneChatsEnabled =
+          BOOLEAN_FIELD_DEFAULTS.get("featureVoiceMessagesOneOnOneChatsEnabled");
+    }
+    if (featureVoiceMessagesGroupChatsEnabled == null) {
+      featureVoiceMessagesGroupChatsEnabled =
+          BOOLEAN_FIELD_DEFAULTS.get("featureVoiceMessagesGroupChatsEnabled");
+    }
+    if (featureVoiceMessagesSupervisionChatsEnabled == null) {
+      featureVoiceMessagesSupervisionChatsEnabled =
+          BOOLEAN_FIELD_DEFAULTS.get("featureVoiceMessagesSupervisionChatsEnabled");
+    }
+    if (featureSystemNotificationEmailsEnabled == null) {
+      featureSystemNotificationEmailsEnabled =
+          BOOLEAN_FIELD_DEFAULTS.get("featureSystemNotificationEmailsEnabled");
+    }
+    if (featureAttachmentUploadDisabled == null) {
+      featureAttachmentUploadDisabled =
+          BOOLEAN_FIELD_DEFAULTS.get("featureAttachmentUploadDisabled");
+    }
+    if (isVideoCallAllowed == null) {
+      isVideoCallAllowed = BOOLEAN_FIELD_DEFAULTS.get("isVideoCallAllowed");
+    }
+    if (showAskerProfile == null) {
+      showAskerProfile = BOOLEAN_FIELD_DEFAULTS.get("showAskerProfile");
+    }
+    if (featureCentralDataProtectionTemplateEnabled == null) {
+      featureCentralDataProtectionTemplateEnabled =
+          BOOLEAN_FIELD_DEFAULTS.get("featureCentralDataProtectionTemplateEnabled");
+    }
+    return this;
+  }
 }

--- a/src/test/java/com/vi/tenantservice/api/converter/TenantConverterTest.java
+++ b/src/test/java/com/vi/tenantservice/api/converter/TenantConverterTest.java
@@ -333,6 +333,54 @@ class TenantConverterTest {
   }
 
   @Test
+  void toDTO_should_applyPerFieldDefaults_When_storedSettingsJsonIsEmpty() {
+    // given — all keys absent from stored JSON
+    TenantEntity entity = TenantEntity.builder().settings("{}").build();
+
+    // when
+    Settings settings = tenantConverter.toDTO(entity, "de").getSettings();
+
+    // then — false-default fields (sample of 3)
+    assertThat(settings.getFeatureDemographicsEnabled()).isFalse();
+    assertThat(settings.getFeatureStatisticsEnabled()).isFalse();
+    assertThat(settings.getFeatureToolsEnabled()).isFalse();
+    // then — true-default fields (sample of 3)
+    assertThat(settings.getFeatureAudioCallsEnabled()).isTrue();
+    assertThat(settings.getFeatureAnonymousChatEnabled()).isTrue();
+    assertThat(settings.getFeatureCallsEnabled()).isTrue();
+  }
+
+  @Test
+  void toDTO_should_respectExplicitFalse_When_trueDefaultFieldIsSetToFalseInJson() {
+    // given — one true-default field explicitly false; all other keys absent
+    TenantEntity entity =
+        TenantEntity.builder().settings("{\"featureAudioCallsEnabled\":false}").build();
+
+    // when
+    Settings settings = tenantConverter.toDTO(entity, "de").getSettings();
+
+    // then
+    assertThat(settings.getFeatureAudioCallsEnabled()).isFalse();
+    assertThat(settings.getFeatureDemographicsEnabled()).isFalse();
+    assertThat(settings.getFeatureAnonymousChatEnabled()).isTrue();
+    assertThat(settings.getFeatureStatisticsEnabled()).isFalse();
+  }
+
+  @Test
+  void toDTO_should_notCrossContaminate_When_jsonContainsMisspelledFieldName() {
+    // given — typo must not satisfy .contains() for the correctly-spelled key
+    TenantEntity entity =
+        TenantEntity.builder().settings("{\"featureAudioCalls_Enabled\":false}").build();
+
+    // when
+    Settings settings = tenantConverter.toDTO(entity, "de").getSettings();
+
+    // then — correctly-spelled field keeps its true default; typo is ignored
+    assertThat(settings.getFeatureAudioCallsEnabled()).isTrue();
+    assertThat(settings.getFeatureDemographicsEnabled()).isFalse();
+  }
+
+  @Test
   void toBasicLicensingTenantDTO_should_convertAttributesProperly() {
     // given
     MultilingualTenantDTO tenantDTO =

--- a/src/test/java/com/vi/tenantservice/api/facade/TenantFacadeChangeDetectionServiceTest.java
+++ b/src/test/java/com/vi/tenantservice/api/facade/TenantFacadeChangeDetectionServiceTest.java
@@ -2,6 +2,7 @@ package com.vi.tenantservice.api.facade;
 
 import static com.vi.tenantservice.api.model.TenantSetting.*;
 import static com.vi.tenantservice.api.util.JsonConverter.convertToJson;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import com.google.common.collect.Maps;
@@ -226,6 +227,40 @@ class TenantFacadeChangeDetectionServiceTest {
             tenantFacadeChangeDetectionService.determineChangedSettings(
                 sanitizedTenantDTO, existingTenant))
         .containsOnly(FEATURE_ATTACHMENT_UPLOAD_DISABLED);
+  }
+
+  @Test
+  void
+      determineChangedSettings_Should_ReportExactlyOneChange_When_StoredAndInputDifferInOneFieldOnly() {
+    // given — stored JSON uses defaults (audioCalls true); input sets only that field to false
+    TenantEntity existingTenant = TenantEntity.builder().settings("{}").build();
+    MultilingualTenantDTO sanitizedTenantDTO =
+        new MultilingualTenantDTO().settings(new Settings().featureAudioCallsEnabled(false));
+
+    // when, then
+    assertThat(
+            tenantFacadeChangeDetectionService.determineChangedSettings(
+                sanitizedTenantDTO, existingTenant))
+        .containsOnly(FEATURE_AUDIO_CALLS_ENABLED);
+  }
+
+  @Test
+  void determineChangedSettings_Should_NotNpe_When_storedJsonLeavesFalseDefaultFieldsAbsent() {
+    // Regresses Boolean-null unboxing in isChanged(Boolean, boolean): after boolean→Boolean,
+    // absent keys deserialize as null and isFeature*() must not be unboxed before defaults apply.
+    TenantEntity existingTenant = TenantEntity.builder().settings("{}").build();
+    MultilingualTenantDTO sanitizedTenantDTO = new MultilingualTenantDTO().settings(new Settings());
+
+    assertThatCode(
+            () ->
+                tenantFacadeChangeDetectionService.determineChangedSettings(
+                    sanitizedTenantDTO, existingTenant))
+        .doesNotThrowAnyException();
+
+    assertThat(
+            tenantFacadeChangeDetectionService.determineChangedSettings(
+                sanitizedTenantDTO, existingTenant))
+        .isEmpty();
   }
 
   @Test

--- a/src/test/java/com/vi/tenantservice/api/util/JsonConverterTest.java
+++ b/src/test/java/com/vi/tenantservice/api/util/JsonConverterTest.java
@@ -71,14 +71,14 @@ class JsonConverterTest {
 
     // then
     assertThat(tenantSettings, notNullValue());
-    assertThat(tenantSettings.isFeatureStatisticsEnabled(), is(true));
-    assertThat(tenantSettings.isFeatureTopicsEnabled(), is(true));
-    assertThat(tenantSettings.isTopicsInRegistrationEnabled(), is(true));
-    assertThat(tenantSettings.isFeatureDemographicsEnabled(), is(false));
-    assertThat(tenantSettings.isFeatureAppointmentsEnabled(), is(false));
-    assertThat(tenantSettings.isFeatureGroupChatV2Enabled(), is(false));
-    assertThat(tenantSettings.isFeatureToolsEnabled(), is(false));
-    assertThat(tenantSettings.isFeatureAttachmentUploadDisabled(), is(true));
+    assertThat(tenantSettings.getFeatureStatisticsEnabled(), is(true));
+    assertThat(tenantSettings.getFeatureTopicsEnabled(), is(true));
+    assertThat(tenantSettings.getTopicsInRegistrationEnabled(), is(true));
+    assertThat(tenantSettings.getFeatureDemographicsEnabled(), is(false));
+    assertThat(tenantSettings.getFeatureAppointmentsEnabled(), is(false));
+    assertThat(tenantSettings.getFeatureGroupChatV2Enabled(), is(false));
+    assertThat(tenantSettings.getFeatureToolsEnabled(), is(false));
+    assertThat(tenantSettings.getFeatureAttachmentUploadDisabled(), is(true));
     assertThat(tenantSettings.getFeatureToolsOIDCToken(), nullValue());
   }
 


### PR DESCRIPTION
## Summary

[Fixes #22 (TS-H01)](https://github.com/OpenResilienceInitiative/ORISO-TenantService/issues/22): replaces ~250 lines of duplicated `settingsJson.contains("\"fieldName\"")` string-matching across `TenantConverter` and `TenantFacadeChangeDetectionService` with a proper nullable `Boolean` model and centralized per-field defaults. The old approach couldn't distinguish "explicitly false" from "missing from JSON" and was fragile to typos (silent failure, wrong default applied with no error).

## Changes Made

- `TenantSettings`: all 38 boolean flags → `Boolean`. Added a central defaults map (12 fields default `false`, 25 default `true`) and `applyDefaults()` to fill nulls after deserialization.
- `TenantConverter.getSettingsIfNotNull()`: replaced 25 `.contains()` checks with Jackson deserialization + `applyDefaults()`.
- `TenantConverter.toEntitySettings()`: incoming nulls are now preserved as null on write (previously forced to true/false) — partial updates now store sparse JSON, relying on `applyDefaults()` at read time.
- `TenantFacadeChangeDetectionService`: removed duplicated defaults block + `.contains()` checks; `isChanged()` signature changed to `(Boolean, Boolean)` for null-safety.

`settingsJson.contains` occurrences in `src/`: 0 (was 50).

**Out of scope (not touched):** `TenantService.getDefaultTenantSettings()` fallback, the two duplicate permission-toggle mappers, and the orphan `featureCentralDataProtectionEnabled` field — separate follow-ups.

## Testing

- 5 new smoke tests added, covering: per-field defaults on empty settings, explicit-false respected without affecting other fields' defaults, typo in field name doesn't cross-contaminate, change detection reports exactly one changed field (not all ~25), no NPE after the Boolean conversion
- All 5 new tests pass
- Zero regressions across 9 related test classes (114 tests total in the module)
- `pom.xml` has `testFailureIgnore=true`, so `mvn test` always reports BUILD SUCCESS regardless of failures — verified via the actual Surefire summary line, not build status