### PR TITLE
TS-M28 add graceful shutdown for rolling deploys

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -58,6 +58,8 @@ spring.datasource.url=${SPRING_DATASOURCE_URL:}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME:}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:}
 server.port = 8081
+server.shutdown=graceful
+spring.lifecycle.timeout-per-shutdown-phase=30s
 
 feature.multitenancy.with.single.domain.enabled=false
 # Use Kubernetes DNS names, e.g., http://consultingtypeservice.caritas.svc.cluster.local:8083


### PR DESCRIPTION
## What
- Added `server.shutdown=graceful` to `application.properties`
- Added `spring.lifecycle.timeout-per-shutdown-phase=30s` to `application.properties`

## Why
Without graceful shutdown, K8s SIGTERM immediately kills the JVM and drops in-flight requests. With graceful shutdown Spring waits up to 30s for active requests to complete. 30s timeout matches UserService (commit fb92ee19).

Note: K8s `terminationGracePeriodSeconds` in the Deployment manifest must be >= 30s for this to take effect.

## Audit
**ID:** TS-M28
**Severity:** Medium
**Batch:** A

## Test
- Deploy to dev, trigger rolling restart via kubectl rollout restart
- Confirm in-flight requests complete before pod terminates
- Confirm terminationGracePeriodSeconds >= 30 in K8s deployment manifest

Closes #34