### PR TITLE
TS-M04 remove debug sql and jwt logging from all deployed profiles

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,10 +1,9 @@
 # Logging: SLF4J (via Lombok)
 logging.level.root=INFO
-logging.level.org.springframework.web=DEBUG
-logging.level.org.springframework.security=DEBUG
+logging.level.org.springframework.web=INFO
+logging.level.org.springframework.security=INFO
 logging.level.org.hibernate=ERROR
-logging.level.org.hibernate.SQL=DEBUG
-logging.level.org.keycloak.adapters=DEBUG
+logging.level.org.keycloak.adapters=INFO
 
 # Keycloak
 # Use Kubernetes DNS names, e.g., http://keycloak.caritas.svc.cluster.local:8080
@@ -28,8 +27,8 @@ spring.liquibase.change-log=classpath:db/changelog/tenantservice-master.xml
 spring.liquibase.contexts=${SPRING_LIQUIBASE_CONTEXTS:seed}
 spring.jpa.hibernate.ddl-auto=${SPRING_JPA_HIBERNATE_DDL_AUTO:validate}
 
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=false
 server.port = 8081
 feature.multitenancy.with.single.domain.enabled=false
 keycloak.ssl-required=none

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -4,7 +4,7 @@ logging.level.org.springframework.web=INFO
 logging.level.org.springframework.security=INFO
 logging.level.org.hibernate=ERROR
 logging.level.org.hibernate.SQL=WARN
-logging.level.org.keycloak.adapters=DEBUG
+logging.level.org.keycloak.adapters=INFO
 
 # Keycloak
 # Use Kubernetes DNS names, e.g., http://keycloak.caritas.svc.cluster.local:8080

--- a/src/main/resources/application-staging.properties
+++ b/src/main/resources/application-staging.properties
@@ -1,11 +1,9 @@
 # Logging: SLF4J (via Lombok)
 logging.level.root=INFO
-logging.level.org.springframework.web=DEBUG
-logging.level.org.springframework.security=DEBUG
+logging.level.org.springframework.web=INFO
+logging.level.org.springframework.security=INFO
 logging.level.org.hibernate=ERROR
-logging.level.org.hibernate.SQL=DEBUG
-logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
-logging.level.org.keycloak.adapters=DEBUG
+logging.level.org.keycloak.adapters=INFO
 
 # Keycloak
 # Use Kubernetes DNS names, e.g., http://keycloak.caritas.svc.cluster.local:8080
@@ -28,8 +26,8 @@ spring.liquibase.change-log=classpath:db/changelog/tenantservice-master.xml
 spring.liquibase.contexts=${SPRING_LIQUIBASE_CONTEXTS:prod}
 spring.jpa.hibernate.ddl-auto=${SPRING_JPA_HIBERNATE_DDL_AUTO:validate}
 
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=false
 server.port = 8081
 feature.multitenancy.with.single.domain.enabled=false
 keycloak.ssl-required=none

--- a/src/main/resources/application-testing.properties
+++ b/src/main/resources/application-testing.properties
@@ -1,11 +1,9 @@
 # Logging: SLF4J (via Lombok)
 logging.level.root=INFO
-logging.level.org.springframework.web=DEBUG
-logging.level.org.springframework.security=DEBUG
+logging.level.org.springframework.web=INFO
+logging.level.org.springframework.security=INFO
 logging.level.org.hibernate=ERROR
-logging.level.org.hibernate.SQL=DEBUG
-logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
-logging.level.org.keycloak.adapters=DEBUG
+logging.level.org.keycloak.adapters=INFO
 
 # Keycloak
 # Use Kubernetes DNS names, e.g., http://keycloak.caritas.svc.cluster.local:8080
@@ -29,14 +27,14 @@ spring.liquibase.enabled=false
 # Database already exists, skip Liquibase migration
 
 spring.jpa.hibernate.ddl-auto=create-drop
-spring.jpa.show-sql=true
+spring.jpa.show-sql=false
 
 # Default tenant settings applied to newly created tenants. Points at the test
 # fixture so createTenant integration tests exercise real default-settings loading
 # instead of falling back to empty defaults. Relative to the module root (the test
 # working directory).
 default.tenant.settings.json.path=src/test/resources/settings/default-tenant-settings.json
-spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.format_sql=false
 server.port = 8081
 feature.multitenancy.with.single.domain.enabled=false
 consulting.type.service.api.url=${CONSULTING_TYPE_SERVICE_API_URL:http://localhost:8083}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,6 @@ logging.level.org.springframework.web=DEBUG
 logging.level.org.hibernate=ERROR
 logging.level.org.springframework.security=INFO
 logging.level.com.vi.tenantservice=DEBUG
-logging.level.org.springframework.web.servlet.DispatcherServlet=DEBUG
 
 # ---------------- Sentry ----------------
 sentry.dsn=${SENTRY_DSN:}
@@ -101,7 +100,6 @@ spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${SPRING_SECURITY_OAUTH2_R
 spring.jwt.auth.converter.resource-id: app
 spring.jwt.auth.converter.principal-attribute: preferred_username
 spring.mvc.pathmatch.matching-strategy=ant_path_matcher
-logging.level.org.springframework.web.servlet.mvc.method.annotation=DEBUG
 
 template.use.custom.resources.path=false
 template.custom.resources.path=false


### PR DESCRIPTION
## What
- `logging.level.org.springframework.web=DEBUG` -> `INFO` in dev, staging, testing
- `logging.level.org.springframework.security=DEBUG` -> `INFO` in dev, staging, testing
- Removed `logging.level.org.hibernate.SQL=DEBUG` from dev, staging, testing
- Removed `logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE` from staging, testing
- `spring.jpa.show-sql=true` -> `false` in dev, staging, testing
- `logging.level.org.keycloak.adapters=DEBUG` -> `INFO` in prod (JWT claim details were leaking)

## Why
Spring Security DEBUG logs emit JWT token claims in plaintext — PII exposure risk in any shared log sink. TRACE SQL binding logs expose parameter values. The keycloak adapter at DEBUG level logs the full decoded JWT on every request in production.

## Audit
**ID:** TS-M04
**Severity:** Medium
**Batch:** C

## Test
- Deploy to dev, tail pod logs — no SQL output, no security DEBUG lines
- Deploy to prod, confirm no JWT claim details in logs (keycloak adapter now at INFO)
- Application behaviour unchanged (property-only change)

Closes #35