### PR TITLE
TS-M02 enable liquibase in dev and local profiles

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -21,8 +21,9 @@ spring.datasource.url=${SPRING_DATASOURCE_URL:}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME:}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:}
 
-# Liquibase
-spring.liquibase.enabled=false
+# Liquibase — enabled in dev so new environments bootstrap from changesets automatically.
+# Prod stays false — schemas managed via ORISO-Database repo (platform-wide decision).
+spring.liquibase.enabled=true
 # Database already exists, skip Liquibase migration
 
 spring.jpa.show-sql=true

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -22,8 +22,8 @@ spring.datasource.url=jdbc:mariadb://178.105.141.133:32493/tenantservice
 spring.datasource.username=root
 spring.datasource.password=admin123!
 
-# Liquibase
-spring.liquibase.enabled=false
+# Liquibase — enabled locally so dev environments bootstrap from changesets automatically.
+spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/tenantservice-local-master.xml
 # Database already exists, skip Liquibase migration
 


### PR DESCRIPTION
﻿## What
- Set `spring.liquibase.enabled=true` in `application-dev.properties` and `application-local.properties`

## Why
Fixes audit finding TS-M02 -- Liquibase was disabled in dev and local profiles, meaning schema migrations were never validated locally or on the shared dev environment.
Closes #36

## Test
- [ ] Service starts on dev profile without Liquibase errors
- [ ] Service starts on local profile without Liquibase errors

## Reviewer checklist
- [ ] Only dev and local properties files changed -- prod/staging untouched
- [ ] No new changesets introduced
