### PR TITLE
TS-M13 TS-L06 deduplicate and parameterize deploy scripts

### DIFF
--- a/check-version.sh
+++ b/check-version.sh
@@ -6,12 +6,12 @@ echo ""
 
 if command -v kubectl &> /dev/null; then
     echo "Checking via Kubernetes service..."
-    kubectl -n caritas exec -it deployment/oriso-platform-tenantservice -c tenantservice -- \
+    kubectl -n "${NAMESPACE:-caritas}" exec -it deployment/oriso-platform-tenantservice -c tenantservice -- \
         curl -s http://localhost:8081/version 2>/dev/null || \
         echo "Service not accessible via kubectl"
     echo ""
     echo "Detailed info:"
-    kubectl -n caritas exec -it deployment/oriso-platform-tenantservice -c tenantservice -- \
+    kubectl -n "${NAMESPACE:-caritas}" exec -it deployment/oriso-platform-tenantservice -c tenantservice -- \
         curl -s http://localhost:8081/version/info 2>/dev/null || \
         echo "Service not accessible via kubectl"
 else

--- a/deploy-development.sh
+++ b/deploy-development.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "Starting TenantService build & deployment..."
-
-# Set Java 17
-export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+NAMESPACE=${NAMESPACE:-caritas}
+DEPLOYMENT=${DEPLOYMENT:-oriso-platform-tenantservice}
+export JAVA_HOME=${JAVA_HOME:-/usr/lib/jvm/java-17-openjdk-amd64}
 export PATH="$JAVA_HOME/bin:$PATH"
 
-# Go to project directory
-cd /root/online-beratung/ORISO-Complete/caritas-workspace/ORISO-TenantService
+echo "Starting TenantService build & deployment..."
+
+cd "$(dirname "$(realpath "$0")")"
 
 echo "Building Maven package..."
 mvn -q -Dmaven.test.skip=true -Dspotless.check.skip=true package
@@ -23,178 +23,9 @@ echo "Importing image into k3s..."
 docker save oriso-tenantservice:latest | sudo k3s ctr images import - > /dev/null 2>&1
 
 echo "Restarting Kubernetes deployment..."
-kubectl rollout restart deployment/oriso-platform-tenantservice -n caritas
+kubectl rollout restart deployment/${DEPLOYMENT} -n ${NAMESPACE}
 
 echo "Waiting for rollout to complete..."
-kubectl rollout status deployment/oriso-platform-tenantservice -n caritas --timeout=180s
+kubectl rollout status deployment/${DEPLOYMENT} -n ${NAMESPACE} --timeout=180s
 
 echo "TenantService deployed successfully ✅"
-
-
-set -euo pipefail
-
-echo "Starting TenantService build & deployment..."
-
-# Set Java 17
-export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
-export PATH="$JAVA_HOME/bin:$PATH"
-
-# Go to project directory
-cd /root/online-beratung/ORISO-Complete/caritas-workspace/ORISO-TenantService
-
-echo "Building Maven package..."
-mvn -q -Dmaven.test.skip=true -Dspotless.check.skip=true package
-
-echo "Copying JAR..."
-cp -f target/TenantService.jar ./TenantService.jar
-
-echo "Building Docker image..."
-docker build -t oriso-tenantservice:latest .
-
-echo "Importing image into k3s..."
-docker save oriso-tenantservice:latest | sudo k3s ctr images import - > /dev/null 2>&1
-
-echo "Restarting Kubernetes deployment..."
-kubectl rollout restart deployment/oriso-platform-tenantservice -n caritas
-
-echo "Waiting for rollout to complete..."
-kubectl rollout status deployment/oriso-platform-tenantservice -n caritas --timeout=180s
-
-echo "TenantService deployed successfully ✅"
-
-
-set -euo pipefail
-
-echo "Starting TenantService build & deployment..."
-
-# Set Java 17
-export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
-export PATH="$JAVA_HOME/bin:$PATH"
-
-# Go to project directory
-cd /root/online-beratung/ORISO-Complete/caritas-workspace/ORISO-TenantService
-
-echo "Building Maven package..."
-mvn -q -Dmaven.test.skip=true -Dspotless.check.skip=true package
-
-echo "Copying JAR..."
-cp -f target/TenantService.jar ./TenantService.jar
-
-echo "Building Docker image..."
-docker build -t oriso-tenantservice:latest .
-
-echo "Importing image into k3s..."
-docker save oriso-tenantservice:latest | sudo k3s ctr images import - > /dev/null 2>&1
-
-echo "Restarting Kubernetes deployment..."
-kubectl rollout restart deployment/oriso-platform-tenantservice -n caritas
-
-echo "Waiting for rollout to complete..."
-kubectl rollout status deployment/oriso-platform-tenantservice -n caritas --timeout=180s
-
-echo "TenantService deployed successfully ✅"
-
-
-set -euo pipefail
-
-echo "Starting TenantService build & deployment..."
-
-# Set Java 17
-export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
-export PATH="$JAVA_HOME/bin:$PATH"
-
-# Go to project directory
-cd /root/online-beratung/ORISO-Complete/caritas-workspace/ORISO-TenantService
-
-echo "Building Maven package..."
-mvn -q -Dmaven.test.skip=true -Dspotless.check.skip=true package
-
-echo "Copying JAR..."
-cp -f target/TenantService.jar ./TenantService.jar
-
-echo "Building Docker image..."
-docker build -t oriso-tenantservice:latest .
-
-echo "Importing image into k3s..."
-docker save oriso-tenantservice:latest | sudo k3s ctr images import - > /dev/null 2>&1
-
-echo "Restarting Kubernetes deployment..."
-kubectl rollout restart deployment/oriso-platform-tenantservice -n caritas
-
-echo "Waiting for rollout to complete..."
-kubectl rollout status deployment/oriso-platform-tenantservice -n caritas --timeout=180s
-
-echo "TenantService deployed successfully ✅"
-
-
-set -euo pipefail
-
-echo "Starting TenantService build & deployment..."
-
-# Set Java 17
-export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
-export PATH="$JAVA_HOME/bin:$PATH"
-
-# Go to project directory
-cd /root/online-beratung/ORISO-Complete/caritas-workspace/ORISO-TenantService
-
-echo "Building Maven package..."
-mvn -q -Dmaven.test.skip=true -Dspotless.check.skip=true package
-
-echo "Copying JAR..."
-cp -f target/TenantService.jar ./TenantService.jar
-
-echo "Building Docker image..."
-docker build -t oriso-tenantservice:latest .
-
-echo "Importing image into k3s..."
-docker save oriso-tenantservice:latest | sudo k3s ctr images import - > /dev/null 2>&1
-
-echo "Restarting Kubernetes deployment..."
-kubectl rollout restart deployment/oriso-platform-tenantservice -n caritas
-
-echo "Waiting for rollout to complete..."
-kubectl rollout status deployment/oriso-platform-tenantservice -n caritas --timeout=180s
-
-echo "TenantService deployed successfully ✅"
-
-
-set -euo pipefail
-
-echo "Starting TenantService build & deployment..."
-
-# Set Java 17
-export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
-export PATH="$JAVA_HOME/bin:$PATH"
-
-# Go to project directory
-cd /root/online-beratung/ORISO-Complete/caritas-workspace/ORISO-TenantService
-
-echo "Building Maven package..."
-mvn -q -Dmaven.test.skip=true -Dspotless.check.skip=true package
-
-echo "Copying JAR..."
-cp -f target/TenantService.jar ./TenantService.jar
-
-echo "Building Docker image..."
-docker build -t oriso-tenantservice:latest .
-
-echo "Importing image into k3s..."
-docker save oriso-tenantservice:latest | sudo k3s ctr images import - > /dev/null 2>&1
-
-echo "Restarting Kubernetes deployment..."
-kubectl rollout restart deployment/oriso-platform-tenantservice -n caritas
-
-echo "Waiting for rollout to complete..."
-kubectl rollout status deployment/oriso-platform-tenantservice -n caritas --timeout=180s
-
-echo "TenantService deployed successfully ✅"
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
﻿## What
- Reduced 6 identical 32-line deploy blocks to a single block (177 lines to 22 lines)
- Replaced hardcoded absolute cd path with script-relative cd using dirname/realpath
- Parameterized namespace, deployment name, and JAVA_HOME with overrideable defaults
- check-version.sh: replaced hardcoded -n caritas with NAMESPACE variable

## Why
Fixes audit findings TS-M13 and TS-L06 -- deploy script had the same block copy-pasted 6 times with a hardcoded machine-specific path and locked namespace, making it unmaintainable and non-portable.
Closes #37

## Test
- [ ] Run deploy-development.sh from repo root on dev server -- confirm build and rollout succeed
- [ ] Run check-version.sh -- confirm it queries the correct namespace

## Reviewer checklist
- [ ] Deduplication is a pure refactor -- no functional changes to build/deploy logic
- [ ] Default values match current production values
