### PR TITLE
fix BadRequestException handler type so bad requests return 400 not 500

### DIFF
--- a/src/main/java/com/vi/tenantservice/api/controller/ExceptionHandlerAdvice.java
+++ b/src/main/java/com/vi/tenantservice/api/controller/ExceptionHandlerAdvice.java
@@ -6,7 +6,6 @@ import com.vi.tenantservice.api.exception.httpresponse.HttpStatusExceptionReason
 import javax.ws.rs.BadRequestException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -36,13 +35,13 @@ public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler {
 
   @ExceptionHandler(value = {IllegalStateException.class})
   @ResponseStatus(value = HttpStatus.BAD_REQUEST)
-  protected void handleIllegalStateException() {
-    // status code is set with ResponseStatus
+  protected void handleIllegalStateException(IllegalStateException e) {
+    logger.warn("Returning HTTP 400 Bad Request for IllegalStateException", e);
   }
 
   @ExceptionHandler(value = {BadRequestException.class})
   @ResponseStatus(HttpStatus.BAD_REQUEST)
-  public void handle(HttpMessageNotReadableException e) {
+  public void handle(BadRequestException e) {
     logger.warn("Returning HTTP 400 Bad Request", e);
   }
 }


### PR DESCRIPTION
## What
- Fixed `handle(HttpMessageNotReadableException e)` → `handle(BadRequestException e)` to match the `@ExceptionHandler` annotation
- Added `IllegalStateException e` parameter and warn logging to `handleIllegalStateException`
- Removed unused `HttpMessageNotReadableException` import

## Why
Fixes audit finding TS-M27 — the handler was registered for `BadRequestException` but declared an incompatible parameter type. Spring could not invoke it, so `BadRequestException` thrown in `TenantServiceFacade` resulted in 500 instead of 400. The `IllegalStateException` handler also silently swallowed all exceptions as 400 with zero logging.
Closes #43

## Test
- [ ] Creating a tenant with invalid data (e.g. bad language key) returns 400 not 500
- [ ] `IllegalStateException` from any service path logs a warning

## Reviewer checklist
- [ ] `@ExceptionHandler(BadRequestException.class)` handler parameter is `BadRequestException e`
- [ ] `handleIllegalStateException` logs the exception
- [ ] No unused imports remain