### PR TITLE
[codex] Add local TenantService development setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# Copy to .env and fill the CHANGE_ME values.
+# .env is ignored by git and must not be committed.
+
+SPRING_DATASOURCE_URL=jdbc:mariadb://CHANGE_ME_HOST:CHANGE_ME_PORT/tenantservice
+SPRING_DATASOURCE_USERNAME=tenantservice
+SPRING_DATASOURCE_PASSWORD=CHANGE_ME
+SPRING_LIQUIBASE_ENABLED=false
+SERVER_SERVLET_CONTEXT_PATH=/service
+
+KEYCLOAK_AUTH_SERVER_URL=https://auth.oriso-dev.site
+KEYCLOAK_REALM=online-beratung
+SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI=https://auth.oriso-dev.site/realms/online-beratung
+SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI=https://auth.oriso-dev.site/realms/online-beratung/protocol/openid-connect/certs
+
+CONSULTING_TYPE_SERVICE_API_URL=https://api.oriso-dev.site/service
+USER_SERVICE_API_URL=http://localhost:8082/service
+FEATURE_MULTITENANCY_WITH_SINGLE_DOMAIN_ENABLED=true
+
+# Local frontend CORS. Leave unset in cluster deployments that use ingress.
+TENANT_CORS_ENABLED=true
+TENANT_CORS_ALLOWED_ORIGINS=http://localhost:9001,http://127.0.0.1:9001
+TENANT_CORS_ALLOWED_PATHS=/**
+
+# Optional if the remote dev API or Keycloak certificates are not trusted by your local JVM.
+# LOCAL_JAVA_TRUSTSTORE=$HOME/.oriso/dev-truststore.jks
+# LOCAL_JAVA_TRUSTSTORE_PASSWORD=changeit

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ cluster IPs because they break when services or pods are recreated.
 
 ## Local Development
 
+For the full mixed local frontend/UserService/TenantService setup, see
+[`documentation/local-development.md`](documentation/local-development.md).
+
 Prerequisites:
 
 - JDK 17

--- a/documentation/local-development.md
+++ b/documentation/local-development.md
@@ -1,0 +1,101 @@
+# Local Development
+
+This setup runs TenantService locally on `localhost:8081`, lets the frontend on
+`localhost:9001` call it directly, and points downstream service calls to the local UserService
+or the configured remote dev API.
+
+## 1. Java
+
+Use Java 17:
+
+```bash
+/usr/libexec/java_home -V
+```
+
+The local run script example auto-detects Java 17 on macOS when `JAVA_HOME` is not already set.
+
+## 2. Create `.env`
+
+Copy the sample config:
+
+```bash
+cp .env.example .env
+```
+
+Fill all `CHANGE_ME` values.
+
+Important values for the mixed local setup:
+
+```env
+SERVER_SERVLET_CONTEXT_PATH=/service
+SPRING_LIQUIBASE_ENABLED=false
+CONSULTING_TYPE_SERVICE_API_URL=https://api.oriso-dev.site/service
+USER_SERVICE_API_URL=http://localhost:8082/service
+TENANT_CORS_ENABLED=true
+TENANT_CORS_ALLOWED_ORIGINS=http://localhost:9001,http://127.0.0.1:9001
+TENANT_CORS_ALLOWED_PATHS=/**
+```
+
+`SERVER_SERVLET_CONTEXT_PATH=/service` means callers must use:
+
+```text
+http://localhost:8081/service
+```
+
+If UserService calls this local TenantService, configure UserService with:
+
+```env
+TENANT_SERVICE_API_URL=http://localhost:8081/service
+```
+
+## 3. Create `run-local-remote-db.sh`
+
+Copy the example script:
+
+```bash
+cp run-local-remote-db.sh.example run-local-remote-db.sh
+chmod +x run-local-remote-db.sh
+```
+
+`run-local-remote-db.sh` is ignored by git because it may contain local secrets.
+
+## 4. Run
+
+```bash
+./run-local-remote-db.sh
+```
+
+Expected local base URL:
+
+```text
+http://localhost:8081/service
+```
+
+## 5. Useful Checks
+
+Check whether TenantService is listening:
+
+```bash
+lsof -nP -iTCP:8081 -sTCP:LISTEN
+```
+
+Check public tenant lookup with the local context path:
+
+```bash
+curl http://localhost:8081/service/tenant/public/id/1
+```
+
+Stop the service with `Ctrl+C` in the terminal running the app.
+
+## Frontend Pairing
+
+Use the frontend local setup with:
+
+```env
+REACT_APP_TENANT_SERVICE_ORIGIN=http://localhost:8081
+REACT_APP_LOCAL_TENANT_ID=1
+```
+
+`REACT_APP_LOCAL_TENANT_ID` sets a localhost `tenantId` cookie because localhost has no tenant
+subdomain. If the local tenant id variable is removed, the frontend keeps the normal cluster/domain
+tenant resolution behavior.

--- a/run-local-remote-db.sh.example
+++ b/run-local-remote-db.sh.example
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copy to run-local-remote-db.sh, fill .env, then:
+# chmod +x run-local-remote-db.sh && ./run-local-remote-db.sh
+# run-local-remote-db.sh is ignored by git; do not commit secrets.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+if [ -z "${JAVA_HOME:-}" ]; then
+  export JAVA_HOME="$(/usr/libexec/java_home -v 17 2>/dev/null || /usr/libexec/java_home)"
+fi
+export PATH="$JAVA_HOME/bin:$PATH"
+
+if [ -f .env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . ./.env
+  set +a
+fi
+
+# Keep Maven on the default JVM truststore. The dev truststore is passed only
+# to the Spring Boot app JVM below, otherwise Maven Central downloads can fail.
+unset JAVA_TOOL_OPTIONS
+
+JVM_ARGUMENTS="--enable-preview"
+if [ -n "${LOCAL_JAVA_TRUSTSTORE:-}" ]; then
+  JVM_ARGUMENTS="${JVM_ARGUMENTS} -Djavax.net.ssl.trustStore=${LOCAL_JAVA_TRUSTSTORE} -Djavax.net.ssl.trustStorePassword=${LOCAL_JAVA_TRUSTSTORE_PASSWORD:-changeit}"
+fi
+
+echo "Datasource: ${SPRING_DATASOURCE_URL}"
+./mvnw spring-boot:run \
+  -Dspring-boot.run.profiles=local \
+  -Dspring-boot.run.jvmArguments="${JVM_ARGUMENTS}"

--- a/src/main/java/com/vi/tenantservice/api/config/CorsConfig.java
+++ b/src/main/java/com/vi/tenantservice/api/config/CorsConfig.java
@@ -1,0 +1,40 @@
+package com.vi.tenantservice.api.config;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+@ConditionalOnProperty(name = "tenant.cors.enabled", havingValue = "true")
+public class CorsConfig {
+
+  @Value("${tenant.cors.allowed.origins}")
+  private String[] allowedOrigins;
+
+  @Value("${tenant.cors.allowed.paths}")
+  private List<String> allowedPaths;
+
+  @Bean
+  public FilterRegistrationBean<CorsFilter> corsFilterRegistrationBean() {
+    var configuration = new CorsConfiguration();
+    configuration.setAllowCredentials(true);
+    configuration.setAllowedOrigins(List.of(allowedOrigins));
+    configuration.setAllowedMethods(List.of("OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE"));
+    configuration.setAllowedHeaders(List.of("*"));
+    configuration.setExposedHeaders(List.of("X-Reason"));
+
+    var source = new UrlBasedCorsConfigurationSource();
+    allowedPaths.forEach(path -> source.registerCorsConfiguration(path, configuration));
+
+    var registrationBean = new FilterRegistrationBean<>(new CorsFilter(source));
+    registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE);
+    return registrationBean;
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,6 +26,10 @@ keycloak.resource=tenant-service
 keycloak.principal-attribute=
 keycloak.cors=false
 
+tenant.cors.enabled=${TENANT_CORS_ENABLED:false}
+tenant.cors.allowed.origins=${TENANT_CORS_ALLOWED_ORIGINS:}
+tenant.cors.allowed.paths=${TENANT_CORS_ALLOWED_PATHS:/tenant/public/**}
+
 app.base.url=
 
 # Springfox/API documentation


### PR DESCRIPTION
## Summary
- Add safe local `.env.example` and `run-local-remote-db.sh.example` files with `CHANGE_ME` placeholders.
- Add TenantService local development docs for frontend/UserService pairing.
- Add optional local CORS support controlled by `TENANT_CORS_ENABLED=true`.

## Why
Mixed local development needs TenantService on `localhost:8081` to accept frontend calls from `localhost:9001`, while keeping cluster deployments on ingress-managed CORS.

## Safety
- CORS filter is disabled by default via `TENANT_CORS_ENABLED=false`.
- Local CORS origins/paths only apply when explicitly enabled.
- No real secrets are committed.

## Validation
- `unset JAVA_TOOL_OPTIONS; export JAVA_HOME=$(/usr/libexec/java_home -v 17); export PATH="$JAVA_HOME/bin:$PATH"; ./mvnw -DskipTests compile` completed successfully.
