### PR TITLE
AVV / Legal flow — DPA model + secure sign flow (review-only, part of #46)

### DIFF
--- a/api/tenantservice.yaml
+++ b/api/tenantservice.yaml
@@ -392,8 +392,70 @@ paths:
           description: BAD REQUEST - invalid/incomplete request or body object
         500:
           description: INTERNAL SERVER ERROR - server encountered unexpected condition
+  /tenant/public/dpa/confirm/{token}:
+    summary: 'Public confirmation (signature) of a tenant Data Processing Agreement'
+    post:
+      tags:
+        - tenant-controller
+      summary: 'Confirms a tenant DPA via a single-use sign token [Authorization: no-auth]'
+      operationId: confirmDataProcessingAgreement
+      parameters:
+        - name: token
+          in: path
+          description: Single-use sign token from the invite link
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DpaSignatureRequestDTO'
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DpaSignatureDTO'
+        400:
+          description: BAD REQUEST - invalid/incomplete request or body object
+        410:
+          description: GONE - token unknown, already used, or expired
+        500:
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
 components:
   schemas:
+    DpaSignatureRequestDTO:
+      type: object
+      required:
+        - signerName
+      properties:
+        signerName:
+          type: string
+          example: "Erika Mustermann"
+        signerPosition:
+          type: string
+          example: "Geschäftsführerin"
+        signerIsMember:
+          type: boolean
+          example: false
+        language:
+          type: string
+          example: "de"
+    DpaSignatureDTO:
+      type: object
+      properties:
+        tenantId:
+          type: long
+        status:
+          type: string
+          example: "SIGNED"
+        signerName:
+          type: string
+        signedAt:
+          type: string
     TenantDTO:
       type: object
       required:

--- a/api/tenantservice.yaml
+++ b/api/tenantservice.yaml
@@ -434,21 +434,25 @@ components:
       properties:
         signerName:
           type: string
+          maxLength: 255
           example: "Erika Mustermann"
         signerPosition:
           type: string
+          maxLength: 255
           example: "Geschäftsführerin"
         signerIsMember:
           type: boolean
           example: false
         language:
           type: string
+          maxLength: 10
           example: "de"
     DpaSignatureDTO:
       type: object
       properties:
         tenantId:
-          type: long
+          type: integer
+          format: int64
         status:
           type: string
           example: "SIGNED"

--- a/src/main/java/com/vi/tenantservice/api/controller/TenantController.java
+++ b/src/main/java/com/vi/tenantservice/api/controller/TenantController.java
@@ -3,11 +3,15 @@ package com.vi.tenantservice.api.controller;
 import com.vi.tenantservice.api.facade.TenantServiceFacade;
 import com.vi.tenantservice.api.model.AdminTenantDTO;
 import com.vi.tenantservice.api.model.BasicTenantLicensingDTO;
+import com.vi.tenantservice.api.model.DpaSignatureDTO;
+import com.vi.tenantservice.api.model.DpaSignatureRequestDTO;
 import com.vi.tenantservice.api.model.MultilingualTenantDTO;
 import com.vi.tenantservice.api.model.RestrictedTenantDTO;
 import com.vi.tenantservice.api.model.TenantAdminControls;
 import com.vi.tenantservice.api.model.TenantDTO;
 import com.vi.tenantservice.api.model.TenantsSearchResultDTO;
+import com.vi.tenantservice.api.service.InvalidDpaSignTokenException;
+import com.vi.tenantservice.api.service.TenantDpaService;
 import com.vi.tenantservice.config.security.AuthorisationService;
 import com.vi.tenantservice.generated.api.controller.TenantApi;
 import com.vi.tenantservice.generated.api.controller.TenantadminApi;
@@ -25,6 +29,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -39,6 +44,36 @@ public class TenantController implements TenantApi, TenantadminApi {
   private final @NonNull TenantServiceFacade tenantServiceFacade;
   private final @NonNull AuthorisationService authorisationService;
   private final @NonNull TenantDtoMapper tenantDtoMapper;
+  private final @NonNull TenantDpaService tenantDpaService;
+
+  /**
+   * Public DPA confirmation via a single-use sign token. No authentication: the token is the
+   * authorisation (an external signer who may not hold a platform account confirms via the link).
+   */
+  @Override
+  public ResponseEntity<DpaSignatureDTO> confirmDataProcessingAgreement(
+      String token, DpaSignatureRequestDTO request) {
+    var signature =
+        tenantDpaService.confirmSignature(
+            token,
+            request.getSignerName(),
+            request.getSignerPosition(),
+            Boolean.TRUE.equals(request.getSignerIsMember()),
+            request.getLanguage());
+    var dto =
+        new DpaSignatureDTO()
+            .tenantId(signature.getTenantId())
+            .status(signature.getStatus() == null ? null : signature.getStatus().name())
+            .signerName(signature.getSignerName())
+            .signedAt(signature.getSignedAt() == null ? null : signature.getSignedAt().toString());
+    return ResponseEntity.ok(dto);
+  }
+
+  @ExceptionHandler(InvalidDpaSignTokenException.class)
+  ResponseEntity<Void> handleInvalidDpaSignToken(InvalidDpaSignTokenException e) {
+    log.info("Rejected DPA sign attempt: {}", e.getMessage());
+    return new ResponseEntity<>(HttpStatus.GONE);
+  }
 
   @Override
   @PreAuthorize("hasAuthority('AUTHORIZATION_GET_TENANT')")

--- a/src/main/java/com/vi/tenantservice/api/model/DpaSignatureStatus.java
+++ b/src/main/java/com/vi/tenantservice/api/model/DpaSignatureStatus.java
@@ -1,0 +1,17 @@
+package com.vi.tenantservice.api.model;
+
+/**
+ * State of a tenant's Data Processing Agreement (Auftragsverarbeitungsvertrag) confirmation.
+ *
+ * <ul>
+ *   <li>{@code PENDING} — invite sent, not yet confirmed (blocks platform work for the tenant).
+ *   <li>{@code SIGNED} — confirmed; unlocks tenant functionality.
+ *   <li>{@code DENIED} — explicitly refused; the tenant/unit is set inactive and auto-deleted after
+ *       365 days.
+ * </ul>
+ */
+public enum DpaSignatureStatus {
+  PENDING,
+  SIGNED,
+  DENIED
+}

--- a/src/main/java/com/vi/tenantservice/api/model/TenantDpaSignatureEntity.java
+++ b/src/main/java/com/vi/tenantservice/api/model/TenantDpaSignatureEntity.java
@@ -79,6 +79,13 @@ public class TenantDpaSignatureEntity {
   @Column(name = "signed_at")
   private LocalDateTime signedAt;
 
+  /** SHA-256 hash of the single-use sign-link token while PENDING; nulled once consumed. */
+  @Column(name = "token_hash")
+  private String tokenHash;
+
+  @Column(name = "token_expires_at")
+  private LocalDateTime tokenExpiresAt;
+
   @Column(name = "create_date", nullable = false)
   private LocalDateTime createDate;
 

--- a/src/main/java/com/vi/tenantservice/api/model/TenantDpaSignatureEntity.java
+++ b/src/main/java/com/vi/tenantservice/api/model/TenantDpaSignatureEntity.java
@@ -1,0 +1,80 @@
+package com.vi.tenantservice.api.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * Records a tenant's confirmation ("signature") of a Data Processing Agreement
+ * (Auftragsverarbeitungsvertrag). The platform stores the confirmation as a record only — there is
+ * no PDF and no real e-signature; a checkbox plus signer details is the legally sufficient artefact
+ * (KDG §29 / DSG-EKD Textform) as long as a real contract stands behind it. The signer may be a
+ * non-member (e.g. a CEO) confirming via a forwarded, single-use invite link.
+ */
+@Entity
+@Table(name = "tenant_dpa_signature")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+public class TenantDpaSignatureEntity {
+
+  @Id
+  @SequenceGenerator(
+      name = "dpa_signature_id_seq",
+      allocationSize = 1,
+      sequenceName = "SEQUENCE_TENANT_DPA_SIGNATURE")
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "dpa_signature_id_seq")
+  @Column(name = "id", updatable = false, nullable = false)
+  private Long id;
+
+  @Column(name = "tenant_id", nullable = false)
+  private Long tenantId;
+
+  /**
+   * The version of the DPA that was confirmed — the tenant's {@code dpa_activation_date} at the
+   * moment of confirmation. Lets the platform tell which contract version a signer agreed to.
+   */
+  @Column(name = "dpa_version")
+  private LocalDateTime dpaVersion;
+
+  @Column(name = "signer_name")
+  private String signerName;
+
+  @Column(name = "signer_position")
+  private String signerPosition;
+
+  /**
+   * Whether the signer is a platform member. {@code false} = an external person (e.g. a CEO) who
+   * confirmed via a forwarded link without holding a platform account.
+   */
+  @Column(name = "signer_is_member")
+  private Boolean signerIsMember;
+
+  /** Language the DPA was presented/confirmed in (e.g. {@code "de"}, {@code "en"}). */
+  @Column(name = "lang")
+  private String language;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "signature_status", nullable = false)
+  private DpaSignatureStatus status;
+
+  @Column(name = "signed_at")
+  private LocalDateTime signedAt;
+
+  @Column(name = "create_date", nullable = false)
+  private LocalDateTime createDate;
+}

--- a/src/main/java/com/vi/tenantservice/api/model/TenantDpaSignatureEntity.java
+++ b/src/main/java/com/vi/tenantservice/api/model/TenantDpaSignatureEntity.java
@@ -1,12 +1,14 @@
 package com.vi.tenantservice.api.model;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -15,6 +17,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.hibernate.type.NumericBooleanConverter;
 
 /**
  * Records a tenant's confirmation ("signature") of a Data Processing Agreement
@@ -62,6 +65,7 @@ public class TenantDpaSignatureEntity {
    * confirmed via a forwarded link without holding a platform account.
    */
   @Column(name = "signer_is_member")
+  @Convert(converter = NumericBooleanConverter.class)
   private Boolean signerIsMember;
 
   /** Language the DPA was presented/confirmed in (e.g. {@code "de"}, {@code "en"}). */
@@ -77,4 +81,15 @@ public class TenantDpaSignatureEntity {
 
   @Column(name = "create_date", nullable = false)
   private LocalDateTime createDate;
+
+  /** Defends the NOT NULL columns regardless of how the entity was constructed. */
+  @PrePersist
+  void applyDefaults() {
+    if (createDate == null) {
+      createDate = LocalDateTime.now();
+    }
+    if (status == null) {
+      status = DpaSignatureStatus.PENDING;
+    }
+  }
 }

--- a/src/main/java/com/vi/tenantservice/api/model/TenantEntity.java
+++ b/src/main/java/com/vi/tenantservice/api/model/TenantEntity.java
@@ -77,6 +77,12 @@ public class TenantEntity {
   @Column(name = "termsandconditions_activation_date")
   private LocalDateTime contentTermsAndConditionsActivationDate;
 
+  @Column(name = "content_dpa")
+  private String contentDataProcessingAgreement;
+
+  @Column(name = "dpa_activation_date")
+  private LocalDateTime contentDataProcessingAgreementActivationDate;
+
   @Column(name = "settings")
   private String settings;
 

--- a/src/main/java/com/vi/tenantservice/api/repository/TenantDpaSignatureRepository.java
+++ b/src/main/java/com/vi/tenantservice/api/repository/TenantDpaSignatureRepository.java
@@ -2,9 +2,13 @@ package com.vi.tenantservice.api.repository;
 
 import com.vi.tenantservice.api.model.DpaSignatureStatus;
 import com.vi.tenantservice.api.model.TenantDpaSignatureEntity;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TenantDpaSignatureRepository
     extends JpaRepository<TenantDpaSignatureEntity, Long> {
@@ -15,4 +19,27 @@ public interface TenantDpaSignatureRepository
 
   Optional<TenantDpaSignatureEntity> findByTokenHashAndStatus(
       String tokenHash, DpaSignatureStatus status);
+
+  /**
+   * Atomically consumes a PENDING sign token: flips it to SIGNED, records the signer, and clears
+   * the token — all in one conditional UPDATE. Only the row that is still PENDING is affected, so
+   * under a concurrent double-submit exactly one caller wins (rows affected = 1) and the rest get
+   * 0. This is what makes "single-use" hold under concurrency (the read-then-write path cannot).
+   */
+  @Modifying(clearAutomatically = true)
+  @Query(
+      "update TenantDpaSignatureEntity s set "
+          + "s.status = com.vi.tenantservice.api.model.DpaSignatureStatus.SIGNED, "
+          + "s.signerName = :signerName, s.signerPosition = :signerPosition, "
+          + "s.signerIsMember = :signerIsMember, s.language = :language, "
+          + "s.signedAt = :now, s.tokenHash = null "
+          + "where s.tokenHash = :tokenHash "
+          + "and s.status = com.vi.tenantservice.api.model.DpaSignatureStatus.PENDING")
+  int consumeSignToken(
+      @Param("tokenHash") String tokenHash,
+      @Param("signerName") String signerName,
+      @Param("signerPosition") String signerPosition,
+      @Param("signerIsMember") Boolean signerIsMember,
+      @Param("language") String language,
+      @Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/vi/tenantservice/api/repository/TenantDpaSignatureRepository.java
+++ b/src/main/java/com/vi/tenantservice/api/repository/TenantDpaSignatureRepository.java
@@ -1,0 +1,14 @@
+package com.vi.tenantservice.api.repository;
+
+import com.vi.tenantservice.api.model.DpaSignatureStatus;
+import com.vi.tenantservice.api.model.TenantDpaSignatureEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TenantDpaSignatureRepository
+    extends JpaRepository<TenantDpaSignatureEntity, Long> {
+
+  List<TenantDpaSignatureEntity> findByTenantId(Long tenantId);
+
+  List<TenantDpaSignatureEntity> findByTenantIdAndStatus(Long tenantId, DpaSignatureStatus status);
+}

--- a/src/main/java/com/vi/tenantservice/api/repository/TenantDpaSignatureRepository.java
+++ b/src/main/java/com/vi/tenantservice/api/repository/TenantDpaSignatureRepository.java
@@ -3,6 +3,7 @@ package com.vi.tenantservice.api.repository;
 import com.vi.tenantservice.api.model.DpaSignatureStatus;
 import com.vi.tenantservice.api.model.TenantDpaSignatureEntity;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TenantDpaSignatureRepository
@@ -11,4 +12,7 @@ public interface TenantDpaSignatureRepository
   List<TenantDpaSignatureEntity> findByTenantId(Long tenantId);
 
   List<TenantDpaSignatureEntity> findByTenantIdAndStatus(Long tenantId, DpaSignatureStatus status);
+
+  Optional<TenantDpaSignatureEntity> findByTokenHashAndStatus(
+      String tokenHash, DpaSignatureStatus status);
 }

--- a/src/main/java/com/vi/tenantservice/api/service/DpaSignToken.java
+++ b/src/main/java/com/vi/tenantservice/api/service/DpaSignToken.java
@@ -1,0 +1,37 @@
+package com.vi.tenantservice.api.service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.HexFormat;
+
+/**
+ * Secure single-use token for the public DPA sign link. The raw 256-bit token is what travels in
+ * the link and is returned to the caller exactly once; only its SHA-256 hash is persisted, so a
+ * database read cannot replay the link.
+ */
+final class DpaSignToken {
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  private DpaSignToken() {}
+
+  /** A 256-bit URL-safe random token. Only this raw value goes in the link; it is never stored. */
+  static String generate() {
+    var bytes = new byte[32];
+    RANDOM.nextBytes(bytes);
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+  }
+
+  /** SHA-256 hex of the raw token — what is persisted and looked up by. */
+  static String hash(String rawToken) {
+    try {
+      var digest = MessageDigest.getInstance("SHA-256");
+      return HexFormat.of().formatHex(digest.digest(rawToken.getBytes(StandardCharsets.UTF_8)));
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 not available", e);
+    }
+  }
+}

--- a/src/main/java/com/vi/tenantservice/api/service/InvalidDpaSignTokenException.java
+++ b/src/main/java/com/vi/tenantservice/api/service/InvalidDpaSignTokenException.java
@@ -1,0 +1,9 @@
+package com.vi.tenantservice.api.service;
+
+/** Thrown when a DPA sign token is unknown, already used (consumed), or expired. */
+public class InvalidDpaSignTokenException extends RuntimeException {
+
+  public InvalidDpaSignTokenException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/vi/tenantservice/api/service/TenantDpaService.java
+++ b/src/main/java/com/vi/tenantservice/api/service/TenantDpaService.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Records and queries tenant confirmations ("signatures") of the Data Processing Agreement
@@ -17,8 +18,8 @@ import org.springframework.stereotype.Service;
  * <p>NOTE (from security review): {@link #getSignatures} and {@link #isSignedForVersion} must never
  * be exposed via an endpoint that takes a caller-supplied tenant id — the calling layer must derive
  * the tenant from the authenticated principal and guard it with admin authorisation, otherwise the
- * signer PII becomes an enumerable IDOR. The public sign flow additionally requires a hashed,
- * single-use, expiring token that is not yet modelled here.
+ * signer PII becomes an enumerable IDOR. The public sign flow is token-based (hashed, single-use,
+ * expiring) and consumed atomically in {@link #confirmSignature}.
  */
 @Service
 @RequiredArgsConstructor
@@ -88,28 +89,44 @@ public class TenantDpaService {
    *
    * @throws InvalidDpaSignTokenException if the token is unknown, already used, or expired.
    */
+  @Transactional
   public TenantDpaSignatureEntity confirmSignature(
       String rawToken,
       String signerName,
       String signerPosition,
       boolean signerIsMember,
       String language) {
+    if (rawToken == null || rawToken.isBlank()) {
+      throw new InvalidDpaSignTokenException("Missing sign token");
+    }
+    var tokenHash = DpaSignToken.hash(rawToken);
     var pending =
         signatureRepository
-            .findByTokenHashAndStatus(DpaSignToken.hash(rawToken), DpaSignatureStatus.PENDING)
+            .findByTokenHashAndStatus(tokenHash, DpaSignatureStatus.PENDING)
             .orElseThrow(
                 () -> new InvalidDpaSignTokenException("Unknown or already-used sign token"));
     if (pending.getTokenExpiresAt() == null
         || pending.getTokenExpiresAt().isBefore(LocalDateTime.now())) {
       throw new InvalidDpaSignTokenException("Sign token has expired");
     }
+    var now = LocalDateTime.now();
+    // Atomic single-use: only the still-PENDING row is updated, so a concurrent double-submit
+    // produces exactly one winner (1 row) and the rest see 0.
+    int consumed =
+        signatureRepository.consumeSignToken(
+            tokenHash, signerName, signerPosition, signerIsMember, language, now);
+    if (consumed == 0) {
+      throw new InvalidDpaSignTokenException("Sign token has already been used");
+    }
+    // The bulk update detached the context (clearAutomatically); build the confirmed view to
+    // return.
     pending.setSignerName(signerName);
     pending.setSignerPosition(signerPosition);
     pending.setSignerIsMember(signerIsMember);
     pending.setLanguage(language);
     pending.setStatus(DpaSignatureStatus.SIGNED);
-    pending.setSignedAt(LocalDateTime.now());
-    pending.setTokenHash(null); // consume — single use
-    return signatureRepository.save(pending);
+    pending.setSignedAt(now);
+    pending.setTokenHash(null);
+    return pending;
   }
 }

--- a/src/main/java/com/vi/tenantservice/api/service/TenantDpaService.java
+++ b/src/main/java/com/vi/tenantservice/api/service/TenantDpaService.java
@@ -1,0 +1,64 @@
+package com.vi.tenantservice.api.service;
+
+import com.vi.tenantservice.api.model.DpaSignatureStatus;
+import com.vi.tenantservice.api.model.TenantDpaSignatureEntity;
+import com.vi.tenantservice.api.repository.TenantDpaSignatureRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * Records and queries tenant confirmations ("signatures") of the Data Processing Agreement
+ * (Auftragsverarbeitungsvertrag). Design-stable core: it deals only with the signature record and
+ * the gate derived from it, independent of where the DPA <em>content</em> ultimately lives.
+ *
+ * <p>NOTE (from security review): {@link #getSignatures} and {@link #isSignedForVersion} must never
+ * be exposed via an endpoint that takes a caller-supplied tenant id — the calling layer must derive
+ * the tenant from the authenticated principal and guard it with admin authorisation, otherwise the
+ * signer PII becomes an enumerable IDOR. The public sign flow additionally requires a hashed,
+ * single-use, expiring token that is not yet modelled here.
+ */
+@Service
+@RequiredArgsConstructor
+public class TenantDpaService {
+
+  private final TenantDpaSignatureRepository signatureRepository;
+
+  /** Persists a SIGNED confirmation of the given DPA version for a tenant. */
+  public TenantDpaSignatureEntity recordSignature(
+      Long tenantId,
+      LocalDateTime dpaVersion,
+      String signerName,
+      String signerPosition,
+      boolean signerIsMember,
+      String language) {
+    var now = LocalDateTime.now();
+    return signatureRepository.save(
+        TenantDpaSignatureEntity.builder()
+            .tenantId(tenantId)
+            .dpaVersion(dpaVersion)
+            .signerName(signerName)
+            .signerPosition(signerPosition)
+            .signerIsMember(signerIsMember)
+            .language(language)
+            .status(DpaSignatureStatus.SIGNED)
+            .signedAt(now)
+            .createDate(now)
+            .build());
+  }
+
+  /** Whether the tenant has a SIGNED confirmation for exactly the given DPA version (the gate). */
+  public boolean isSignedForVersion(Long tenantId, LocalDateTime dpaVersion) {
+    if (dpaVersion == null) {
+      return false;
+    }
+    return signatureRepository.findByTenantIdAndStatus(tenantId, DpaSignatureStatus.SIGNED).stream()
+        .anyMatch(signature -> dpaVersion.equals(signature.getDpaVersion()));
+  }
+
+  /** All confirmations for a tenant (for the platform-admin list of confirmed AVVs). */
+  public List<TenantDpaSignatureEntity> getSignatures(Long tenantId) {
+    return signatureRepository.findByTenantId(tenantId);
+  }
+}

--- a/src/main/java/com/vi/tenantservice/api/service/TenantDpaService.java
+++ b/src/main/java/com/vi/tenantservice/api/service/TenantDpaService.java
@@ -3,6 +3,7 @@ package com.vi.tenantservice.api.service;
 import com.vi.tenantservice.api.model.DpaSignatureStatus;
 import com.vi.tenantservice.api.model.TenantDpaSignatureEntity;
 import com.vi.tenantservice.api.repository.TenantDpaSignatureRepository;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -60,5 +61,55 @@ public class TenantDpaService {
   /** All confirmations for a tenant (for the platform-admin list of confirmed AVVs). */
   public List<TenantDpaSignatureEntity> getSignatures(Long tenantId) {
     return signatureRepository.findByTenantId(tenantId);
+  }
+
+  /**
+   * Creates a PENDING confirmation carrying a single-use, expiring sign token and returns the RAW
+   * token (caller builds the public sign link from it). Only the token's hash is persisted.
+   */
+  public String createSignInvite(Long tenantId, LocalDateTime dpaVersion, Duration ttl) {
+    var rawToken = DpaSignToken.generate();
+    var now = LocalDateTime.now();
+    signatureRepository.save(
+        TenantDpaSignatureEntity.builder()
+            .tenantId(tenantId)
+            .dpaVersion(dpaVersion)
+            .status(DpaSignatureStatus.PENDING)
+            .tokenHash(DpaSignToken.hash(rawToken))
+            .tokenExpiresAt(now.plus(ttl))
+            .createDate(now)
+            .build());
+    return rawToken;
+  }
+
+  /**
+   * Confirms a DPA via its single-use sign token: looks up the PENDING row by token hash, validates
+   * it is not expired, records the signer, marks it SIGNED, and consumes the token.
+   *
+   * @throws InvalidDpaSignTokenException if the token is unknown, already used, or expired.
+   */
+  public TenantDpaSignatureEntity confirmSignature(
+      String rawToken,
+      String signerName,
+      String signerPosition,
+      boolean signerIsMember,
+      String language) {
+    var pending =
+        signatureRepository
+            .findByTokenHashAndStatus(DpaSignToken.hash(rawToken), DpaSignatureStatus.PENDING)
+            .orElseThrow(
+                () -> new InvalidDpaSignTokenException("Unknown or already-used sign token"));
+    if (pending.getTokenExpiresAt() == null
+        || pending.getTokenExpiresAt().isBefore(LocalDateTime.now())) {
+      throw new InvalidDpaSignTokenException("Sign token has expired");
+    }
+    pending.setSignerName(signerName);
+    pending.setSignerPosition(signerPosition);
+    pending.setSignerIsMember(signerIsMember);
+    pending.setLanguage(language);
+    pending.setStatus(DpaSignatureStatus.SIGNED);
+    pending.setSignedAt(LocalDateTime.now());
+    pending.setTokenHash(null); // consume — single use
+    return signatureRepository.save(pending);
   }
 }

--- a/src/main/resources/db/changelog/changeset/0015_add_tenant_dpa/0015-changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0015_add_tenant_dpa/0015-changeSet.xml
@@ -1,0 +1,9 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+    <changeSet author="oriso" id="addTenantDpa">
+        <sqlFile path="db/changelog/changeset/0015_add_tenant_dpa/addTenantDpa.sql" stripComments="true" />
+        <rollback>
+            <sqlFile path="db/changelog/changeset/0015_add_tenant_dpa/addTenantDpa-rollback.sql" stripComments="true" />
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0015_add_tenant_dpa/addTenantDpa-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0015_add_tenant_dpa/addTenantDpa-rollback.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `tenantservice`.`tenant` DROP COLUMN IF EXISTS content_dpa;
+ALTER TABLE `tenantservice`.`tenant` DROP COLUMN IF EXISTS dpa_activation_date;

--- a/src/main/resources/db/changelog/changeset/0015_add_tenant_dpa/addTenantDpa.sql
+++ b/src/main/resources/db/changelog/changeset/0015_add_tenant_dpa/addTenantDpa.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `tenantservice`.`tenant` ADD COLUMN IF NOT EXISTS content_dpa LONGTEXT NULL;
+ALTER TABLE `tenantservice`.`tenant` ADD COLUMN IF NOT EXISTS dpa_activation_date DATETIME NULL;

--- a/src/main/resources/db/changelog/changeset/0016_tenant_dpa_signature/0016-changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0016_tenant_dpa_signature/0016-changeSet.xml
@@ -1,0 +1,9 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+    <changeSet author="oriso" id="createTenantDpaSignature">
+        <sqlFile path="db/changelog/changeset/0016_tenant_dpa_signature/createTenantDpaSignature.sql" stripComments="true" />
+        <rollback>
+            <sqlFile path="db/changelog/changeset/0016_tenant_dpa_signature/createTenantDpaSignature-rollback.sql" stripComments="true" />
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0016_tenant_dpa_signature/createTenantDpaSignature-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0016_tenant_dpa_signature/createTenantDpaSignature-rollback.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS `tenantservice`.`tenant_dpa_signature`;
+DROP SEQUENCE IF EXISTS `tenantservice`.`SEQUENCE_TENANT_DPA_SIGNATURE`;

--- a/src/main/resources/db/changelog/changeset/0016_tenant_dpa_signature/createTenantDpaSignature.sql
+++ b/src/main/resources/db/changelog/changeset/0016_tenant_dpa_signature/createTenantDpaSignature.sql
@@ -1,0 +1,16 @@
+CREATE SEQUENCE IF NOT EXISTS `tenantservice`.`SEQUENCE_TENANT_DPA_SIGNATURE` START WITH 100000 INCREMENT BY 1;
+
+CREATE TABLE IF NOT EXISTS `tenantservice`.`tenant_dpa_signature` (
+    id bigint NOT NULL,
+    tenant_id bigint NOT NULL,
+    dpa_version datetime NULL,
+    signer_name varchar(255) NULL,
+    signer_position varchar(255) NULL,
+    signer_is_member tinyint(1) NULL,
+    lang varchar(10) NULL,
+    signature_status varchar(20) NOT NULL DEFAULT 'PENDING',
+    signed_at datetime NULL,
+    create_date datetime NOT NULL,
+    PRIMARY KEY (id),
+    KEY idx_tenant_dpa_signature_tenant (tenant_id)
+);

--- a/src/main/resources/db/changelog/changeset/0016_tenant_dpa_signature/createTenantDpaSignature.sql
+++ b/src/main/resources/db/changelog/changeset/0016_tenant_dpa_signature/createTenantDpaSignature.sql
@@ -12,5 +12,7 @@ CREATE TABLE IF NOT EXISTS `tenantservice`.`tenant_dpa_signature` (
     signed_at datetime NULL,
     create_date datetime NOT NULL,
     PRIMARY KEY (id),
-    KEY idx_tenant_dpa_signature_tenant (tenant_id)
+    KEY idx_tenant_dpa_signature_tenant (tenant_id),
+    CONSTRAINT fk_tenant_dpa_signature_tenant FOREIGN KEY (tenant_id)
+        REFERENCES `tenantservice`.`tenant` (id) ON DELETE CASCADE
 );

--- a/src/main/resources/db/changelog/changeset/0017_tenant_dpa_signature_token/0017-changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0017_tenant_dpa_signature_token/0017-changeSet.xml
@@ -1,0 +1,9 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+    <changeSet author="oriso" id="addTenantDpaSignatureToken">
+        <sqlFile path="db/changelog/changeset/0017_tenant_dpa_signature_token/addTenantDpaSignatureToken.sql" stripComments="true" />
+        <rollback>
+            <sqlFile path="db/changelog/changeset/0017_tenant_dpa_signature_token/addTenantDpaSignatureToken-rollback.sql" stripComments="true" />
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0017_tenant_dpa_signature_token/addTenantDpaSignatureToken-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0017_tenant_dpa_signature_token/addTenantDpaSignatureToken-rollback.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `tenantservice`.`tenant_dpa_signature` DROP COLUMN IF EXISTS token_hash;
+ALTER TABLE `tenantservice`.`tenant_dpa_signature` DROP COLUMN IF EXISTS token_expires_at;

--- a/src/main/resources/db/changelog/changeset/0017_tenant_dpa_signature_token/addTenantDpaSignatureToken.sql
+++ b/src/main/resources/db/changelog/changeset/0017_tenant_dpa_signature_token/addTenantDpaSignatureToken.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `tenantservice`.`tenant_dpa_signature` ADD COLUMN IF NOT EXISTS token_hash varchar(64) NULL;
+ALTER TABLE `tenantservice`.`tenant_dpa_signature` ADD COLUMN IF NOT EXISTS token_expires_at datetime NULL;

--- a/src/main/resources/db/changelog/tenantservice-dev-master.xml
+++ b/src/main/resources/db/changelog/tenantservice-dev-master.xml
@@ -21,4 +21,6 @@
   <include file="db/changelog/changeset/0010_add_association_logo/0010-addAssociationLogo.xml"/>
   <include file="db/changelog/changeset/0013_tenant_admin_controls/0013-changeSet.xml"/>
   <include file="db/changelog/changeset/0014_add_tenant_address_description/0014-changeSet.xml"/>
+  <include file="db/changelog/changeset/0015_add_tenant_dpa/0015-changeSet.xml"/>
+  <include file="db/changelog/changeset/0016_tenant_dpa_signature/0016-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenantservice-dev-master.xml
+++ b/src/main/resources/db/changelog/tenantservice-dev-master.xml
@@ -23,4 +23,5 @@
   <include file="db/changelog/changeset/0014_add_tenant_address_description/0014-changeSet.xml"/>
   <include file="db/changelog/changeset/0015_add_tenant_dpa/0015-changeSet.xml"/>
   <include file="db/changelog/changeset/0016_tenant_dpa_signature/0016-changeSet.xml"/>
+  <include file="db/changelog/changeset/0017_tenant_dpa_signature_token/0017-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenantservice-local-master.xml
+++ b/src/main/resources/db/changelog/tenantservice-local-master.xml
@@ -23,4 +23,5 @@
 	<include file="db/changelog/changeset/0014_add_tenant_address_description/0014-changeSet.xml"/>
 	<include file="db/changelog/changeset/0015_add_tenant_dpa/0015-changeSet.xml"/>
 	<include file="db/changelog/changeset/0016_tenant_dpa_signature/0016-changeSet.xml"/>
+	<include file="db/changelog/changeset/0017_tenant_dpa_signature_token/0017-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenantservice-local-master.xml
+++ b/src/main/resources/db/changelog/tenantservice-local-master.xml
@@ -21,4 +21,6 @@
 	<include file="db/changelog/changeset/0010_add_association_logo/0010-addAssociationLogo.xml"/>
 	<include file="db/changelog/changeset/0013_tenant_admin_controls/0013-changeSet.xml"/>
 	<include file="db/changelog/changeset/0014_add_tenant_address_description/0014-changeSet.xml"/>
+	<include file="db/changelog/changeset/0015_add_tenant_dpa/0015-changeSet.xml"/>
+	<include file="db/changelog/changeset/0016_tenant_dpa_signature/0016-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenantservice-prod-master.xml
+++ b/src/main/resources/db/changelog/tenantservice-prod-master.xml
@@ -20,4 +20,5 @@
   <include file="db/changelog/changeset/0014_add_tenant_address_description/0014-changeSet.xml"/>
   <include file="db/changelog/changeset/0015_add_tenant_dpa/0015-changeSet.xml"/>
   <include file="db/changelog/changeset/0016_tenant_dpa_signature/0016-changeSet.xml"/>
+  <include file="db/changelog/changeset/0017_tenant_dpa_signature_token/0017-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenantservice-prod-master.xml
+++ b/src/main/resources/db/changelog/tenantservice-prod-master.xml
@@ -18,4 +18,6 @@
   <include file="db/changelog/changeset/0010_add_association_logo/0010-addAssociationLogo.xml"/>
   <include file="db/changelog/changeset/0013_tenant_admin_controls/0013-changeSet.xml"/>
   <include file="db/changelog/changeset/0014_add_tenant_address_description/0014-changeSet.xml"/>
+  <include file="db/changelog/changeset/0015_add_tenant_dpa/0015-changeSet.xml"/>
+  <include file="db/changelog/changeset/0016_tenant_dpa_signature/0016-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenantservice-staging-master.xml
+++ b/src/main/resources/db/changelog/tenantservice-staging-master.xml
@@ -20,4 +20,5 @@
   <include file="db/changelog/changeset/0014_add_tenant_address_description/0014-changeSet.xml"/>
   <include file="db/changelog/changeset/0015_add_tenant_dpa/0015-changeSet.xml"/>
   <include file="db/changelog/changeset/0016_tenant_dpa_signature/0016-changeSet.xml"/>
+  <include file="db/changelog/changeset/0017_tenant_dpa_signature_token/0017-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenantservice-staging-master.xml
+++ b/src/main/resources/db/changelog/tenantservice-staging-master.xml
@@ -18,4 +18,6 @@
   <include file="db/changelog/changeset/0010_add_association_logo/0010-addAssociationLogo.xml"/>
   <include file="db/changelog/changeset/0013_tenant_admin_controls/0013-changeSet.xml"/>
   <include file="db/changelog/changeset/0014_add_tenant_address_description/0014-changeSet.xml"/>
+  <include file="db/changelog/changeset/0015_add_tenant_dpa/0015-changeSet.xml"/>
+  <include file="db/changelog/changeset/0016_tenant_dpa_signature/0016-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/test/java/com/vi/tenantservice/api/controller/TenantControllerDpaConfirmTest.java
+++ b/src/test/java/com/vi/tenantservice/api/controller/TenantControllerDpaConfirmTest.java
@@ -1,0 +1,70 @@
+package com.vi.tenantservice.api.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.vi.tenantservice.api.facade.TenantServiceFacade;
+import com.vi.tenantservice.api.model.DpaSignatureRequestDTO;
+import com.vi.tenantservice.api.model.DpaSignatureStatus;
+import com.vi.tenantservice.api.model.TenantDpaSignatureEntity;
+import com.vi.tenantservice.api.service.InvalidDpaSignTokenException;
+import com.vi.tenantservice.api.service.TenantDpaService;
+import com.vi.tenantservice.config.security.AuthorisationService;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class TenantControllerDpaConfirmTest {
+
+  @Mock private TenantServiceFacade tenantServiceFacade;
+  @Mock private AuthorisationService authorisationService;
+  @Mock private TenantDtoMapper tenantDtoMapper;
+  @Mock private TenantDpaService tenantDpaService;
+  @InjectMocks private TenantController controller;
+
+  @Test
+  void confirmDataProcessingAgreement_Should_returnOkWithMappedDto() {
+    // given
+    var request =
+        new DpaSignatureRequestDTO()
+            .signerName("Erika M")
+            .signerPosition("Geschäftsführerin")
+            .signerIsMember(false)
+            .language("de");
+    var signedAt = LocalDateTime.now();
+    var entity =
+        TenantDpaSignatureEntity.builder()
+            .tenantId(7L)
+            .status(DpaSignatureStatus.SIGNED)
+            .signerName("Erika M")
+            .signedAt(signedAt)
+            .build();
+    when(tenantDpaService.confirmSignature("tok", "Erika M", "Geschäftsführerin", false, "de"))
+        .thenReturn(entity);
+
+    // when
+    var response = controller.confirmDataProcessingAgreement("tok", request);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().getTenantId()).isEqualTo(7L);
+    assertThat(response.getBody().getStatus()).isEqualTo("SIGNED");
+    assertThat(response.getBody().getSignerName()).isEqualTo("Erika M");
+  }
+
+  @Test
+  void handleInvalidDpaSignToken_Should_return410Gone() {
+    // when
+    var response =
+        controller.handleInvalidDpaSignToken(new InvalidDpaSignTokenException("expired"));
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.GONE);
+  }
+}

--- a/src/test/java/com/vi/tenantservice/api/model/TenantDpaSignatureEntityTest.java
+++ b/src/test/java/com/vi/tenantservice/api/model/TenantDpaSignatureEntityTest.java
@@ -1,0 +1,33 @@
+package com.vi.tenantservice.api.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+/** Pure unit test for the @PrePersist NOT-NULL defaulting (no DB). */
+class TenantDpaSignatureEntityTest {
+
+  @Test
+  void applyDefaults_Should_setPendingAndCreateDate_When_unset() {
+    var entity = new TenantDpaSignatureEntity();
+
+    entity.applyDefaults();
+
+    assertThat(entity.getStatus()).isEqualTo(DpaSignatureStatus.PENDING);
+    assertThat(entity.getCreateDate()).isNotNull();
+  }
+
+  @Test
+  void applyDefaults_Should_notOverwrite_When_alreadySet() {
+    var fixed = LocalDateTime.of(2020, 1, 1, 0, 0);
+    var entity = new TenantDpaSignatureEntity();
+    entity.setStatus(DpaSignatureStatus.SIGNED);
+    entity.setCreateDate(fixed);
+
+    entity.applyDefaults();
+
+    assertThat(entity.getStatus()).isEqualTo(DpaSignatureStatus.SIGNED);
+    assertThat(entity.getCreateDate()).isEqualTo(fixed);
+  }
+}

--- a/src/test/java/com/vi/tenantservice/api/repository/TenantDpaSignatureRepositoryTest.java
+++ b/src/test/java/com/vi/tenantservice/api/repository/TenantDpaSignatureRepositoryTest.java
@@ -1,0 +1,124 @@
+package com.vi.tenantservice.api.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.vi.tenantservice.api.model.DpaSignatureStatus;
+import com.vi.tenantservice.api.model.TenantDpaSignatureEntity;
+import com.vi.tenantservice.api.model.TenantEntity;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * Self-contained persistence test for the AVV / Data Processing Agreement model. The module's other
+ * {@code @DataJpaTest} repository tests assume an externally provisioned schema (the configured
+ * MariaDB dialect produces DDL that an empty embedded H2 cannot build), so this test overrides the
+ * dialect to H2 and lets Hibernate create the schema from the entities — making it runnable and
+ * meaningful in a bare local build.
+ */
+@TestPropertySource(
+    properties = {
+      "spring.profiles.active=testing",
+      "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
+      "spring.jpa.hibernate.ddl-auto=create-drop"
+    })
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+class TenantDpaSignatureRepositoryTest {
+
+  @Autowired private TenantDpaSignatureRepository signatureRepository;
+  @Autowired private TenantRepository tenantRepository;
+
+  @Test
+  void tenantEntity_Should_persistDataProcessingAgreementFields() {
+    // given
+    TenantEntity entity = new TenantEntity();
+    entity.setName("avv tenant");
+    entity.setSubdomain("avv-subdomain");
+    entity.setCreateDate(LocalDateTime.now());
+    entity.setContentDataProcessingAgreement("<p>Auftragsverarbeitungsvertrag</p>");
+    entity.setContentDataProcessingAgreementActivationDate(LocalDateTime.now());
+
+    // when
+    TenantEntity saved = tenantRepository.save(entity);
+    tenantRepository.flush();
+
+    // then
+    Optional<TenantEntity> reloaded = tenantRepository.findById(saved.getId());
+    assertThat(reloaded).isPresent();
+    assertThat(reloaded.get().getContentDataProcessingAgreement())
+        .isEqualTo("<p>Auftragsverarbeitungsvertrag</p>");
+    assertThat(reloaded.get().getContentDataProcessingAgreementActivationDate()).isNotNull();
+  }
+
+  @Test
+  void save_Should_persistSignatureAndFindByTenantId() {
+    // given
+    var now = LocalDateTime.now();
+    TenantDpaSignatureEntity signature =
+        TenantDpaSignatureEntity.builder()
+            .tenantId(1L)
+            .dpaVersion(now.minusDays(1))
+            .signerName("Erika Mustermann")
+            .signerPosition("Geschäftsführerin")
+            .signerIsMember(false)
+            .language("de")
+            .status(DpaSignatureStatus.SIGNED)
+            .signedAt(now)
+            .createDate(now)
+            .build();
+
+    // when
+    signatureRepository.save(signature);
+    signatureRepository.flush();
+
+    // then
+    List<TenantDpaSignatureEntity> found = signatureRepository.findByTenantId(1L);
+    assertThat(found).hasSize(1);
+    var saved = found.get(0);
+    assertThat(saved.getId()).isNotNull();
+    assertThat(saved.getSignerName()).isEqualTo("Erika Mustermann");
+    assertThat(saved.getSignerPosition()).isEqualTo("Geschäftsführerin");
+    assertThat(saved.getSignerIsMember()).isFalse();
+    assertThat(saved.getStatus()).isEqualTo(DpaSignatureStatus.SIGNED);
+    assertThat(saved.getLanguage()).isEqualTo("de");
+  }
+
+  @Test
+  void findByTenantIdAndStatus_Should_filterByStatus() {
+    // given
+    var now = LocalDateTime.now();
+    signatureRepository.save(
+        TenantDpaSignatureEntity.builder()
+            .tenantId(2L)
+            .status(DpaSignatureStatus.SIGNED)
+            .signerName("Signed Person")
+            .dpaVersion(now)
+            .createDate(now)
+            .build());
+    signatureRepository.save(
+        TenantDpaSignatureEntity.builder()
+            .tenantId(2L)
+            .status(DpaSignatureStatus.DENIED)
+            .signerName("Denied Person")
+            .dpaVersion(now)
+            .createDate(now)
+            .build());
+    signatureRepository.flush();
+
+    // when
+    var signed = signatureRepository.findByTenantIdAndStatus(2L, DpaSignatureStatus.SIGNED);
+
+    // then
+    assertThat(signed).hasSize(1);
+    assertThat(signed.get(0).getSignerName()).isEqualTo("Signed Person");
+  }
+}

--- a/src/test/java/com/vi/tenantservice/api/repository/TenantDpaSignatureRepositoryTest.java
+++ b/src/test/java/com/vi/tenantservice/api/repository/TenantDpaSignatureRepositoryTest.java
@@ -121,4 +121,35 @@ class TenantDpaSignatureRepositoryTest {
     assertThat(signed).hasSize(1);
     assertThat(signed.get(0).getSignerName()).isEqualTo("Signed Person");
   }
+
+  @Test
+  void consumeSignToken_Should_signExactlyOnce_andRejectReuse() {
+    // given a PENDING row carrying a token
+    var now = LocalDateTime.now();
+    var pending =
+        signatureRepository.saveAndFlush(
+            TenantDpaSignatureEntity.builder()
+                .tenantId(3L)
+                .status(DpaSignatureStatus.PENDING)
+                .tokenHash("HASH")
+                .tokenExpiresAt(now.plusDays(1))
+                .createDate(now)
+                .build());
+
+    // when the first consume wins
+    int first = signatureRepository.consumeSignToken("HASH", "Erika", "GF", false, "de", now);
+    // and a second consume of the same token affects nothing (single-use)
+    int second = signatureRepository.consumeSignToken("HASH", "Mallory", "X", true, "en", now);
+    signatureRepository.flush();
+
+    // then
+    assertThat(first).isEqualTo(1);
+    assertThat(second).isZero();
+    var reloaded = signatureRepository.findById(pending.getId()).orElseThrow();
+    assertThat(reloaded.getStatus()).isEqualTo(DpaSignatureStatus.SIGNED);
+    assertThat(reloaded.getSignerName()).isEqualTo("Erika"); // not overwritten by the 2nd attempt
+    assertThat(reloaded.getTokenHash()).isNull();
+    assertThat(signatureRepository.findByTokenHashAndStatus("HASH", DpaSignatureStatus.PENDING))
+        .isEmpty();
+  }
 }

--- a/src/test/java/com/vi/tenantservice/api/service/TenantDpaServiceTest.java
+++ b/src/test/java/com/vi/tenantservice/api/service/TenantDpaServiceTest.java
@@ -3,7 +3,9 @@ package com.vi.tenantservice.api.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.vi.tenantservice.api.model.DpaSignatureStatus;
@@ -122,18 +124,55 @@ class TenantDpaServiceTest {
     when(signatureRepository.findByTokenHashAndStatus(
             DpaSignToken.hash(rawToken), DpaSignatureStatus.PENDING))
         .thenReturn(Optional.of(pending));
-    when(signatureRepository.save(any(TenantDpaSignatureEntity.class)))
-        .thenAnswer(invocation -> invocation.getArgument(0));
+    when(signatureRepository.consumeSignToken(
+            eq(DpaSignToken.hash(rawToken)),
+            eq("Erika M"),
+            eq("Geschäftsführerin"),
+            eq(false),
+            eq("de"),
+            any(LocalDateTime.class)))
+        .thenReturn(1);
 
     // when
     var result =
         tenantDpaService.confirmSignature(rawToken, "Erika M", "Geschäftsführerin", false, "de");
 
     // then
+    verify(signatureRepository)
+        .consumeSignToken(any(), any(), any(), any(), any(), any(LocalDateTime.class));
     assertThat(result.getStatus()).isEqualTo(DpaSignatureStatus.SIGNED);
     assertThat(result.getSignerName()).isEqualTo("Erika M");
     assertThat(result.getSignedAt()).isNotNull();
     assertThat(result.getTokenHash()).isNull(); // consumed -> single use
+  }
+
+  @Test
+  void confirmSignature_Should_throw_When_tokenNullOrBlank() {
+    // when / then
+    assertThatThrownBy(() -> tenantDpaService.confirmSignature(" ", "n", "p", false, "de"))
+        .isInstanceOf(InvalidDpaSignTokenException.class);
+    verifyNoInteractions(signatureRepository);
+  }
+
+  @Test
+  void confirmSignature_Should_throw_When_lostConcurrentRace() {
+    // given a valid, non-expired PENDING row, but the atomic consume affects 0 rows (someone won)
+    var rawToken = "race-token";
+    var pending =
+        TenantDpaSignatureEntity.builder()
+            .status(DpaSignatureStatus.PENDING)
+            .tokenHash(DpaSignToken.hash(rawToken))
+            .tokenExpiresAt(LocalDateTime.now().plusDays(1))
+            .build();
+    when(signatureRepository.findByTokenHashAndStatus(
+            DpaSignToken.hash(rawToken), DpaSignatureStatus.PENDING))
+        .thenReturn(Optional.of(pending));
+    when(signatureRepository.consumeSignToken(any(), any(), any(), any(), any(), any()))
+        .thenReturn(0);
+
+    // when / then
+    assertThatThrownBy(() -> tenantDpaService.confirmSignature(rawToken, "n", "p", false, "de"))
+        .isInstanceOf(InvalidDpaSignTokenException.class);
   }
 
   @Test

--- a/src/test/java/com/vi/tenantservice/api/service/TenantDpaServiceTest.java
+++ b/src/test/java/com/vi/tenantservice/api/service/TenantDpaServiceTest.java
@@ -1,0 +1,92 @@
+package com.vi.tenantservice.api.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.vi.tenantservice.api.model.DpaSignatureStatus;
+import com.vi.tenantservice.api.model.TenantDpaSignatureEntity;
+import com.vi.tenantservice.api.repository.TenantDpaSignatureRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TenantDpaServiceTest {
+
+  @Mock private TenantDpaSignatureRepository signatureRepository;
+  @InjectMocks private TenantDpaService tenantDpaService;
+
+  @Test
+  void recordSignature_Should_persistSignedRecordWithVersionAndSigner() {
+    // given
+    var version = LocalDateTime.now().minusDays(1);
+    when(signatureRepository.save(any(TenantDpaSignatureEntity.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    // when
+    var result =
+        tenantDpaService.recordSignature(5L, version, "Erika M", "Geschäftsführerin", false, "de");
+
+    // then
+    var captor = ArgumentCaptor.forClass(TenantDpaSignatureEntity.class);
+    verify(signatureRepository).save(captor.capture());
+    var saved = captor.getValue();
+    assertThat(saved.getTenantId()).isEqualTo(5L);
+    assertThat(saved.getStatus()).isEqualTo(DpaSignatureStatus.SIGNED);
+    assertThat(saved.getDpaVersion()).isEqualTo(version);
+    assertThat(saved.getSignerName()).isEqualTo("Erika M");
+    assertThat(saved.getSignerPosition()).isEqualTo("Geschäftsführerin");
+    assertThat(saved.getSignerIsMember()).isFalse();
+    assertThat(saved.getLanguage()).isEqualTo("de");
+    assertThat(saved.getSignedAt()).isNotNull();
+    assertThat(saved.getCreateDate()).isNotNull();
+    assertThat(result).isSameAs(saved);
+  }
+
+  @Test
+  void isSignedForVersion_Should_returnTrue_When_signedSignatureForThatVersionExists() {
+    // given
+    var version = LocalDateTime.now();
+    when(signatureRepository.findByTenantIdAndStatus(5L, DpaSignatureStatus.SIGNED))
+        .thenReturn(List.of(signature(version)));
+
+    // when / then
+    assertThat(tenantDpaService.isSignedForVersion(5L, version)).isTrue();
+  }
+
+  @Test
+  void isSignedForVersion_Should_returnFalse_When_onlyOtherVersionsSigned() {
+    // given
+    var version = LocalDateTime.now();
+    when(signatureRepository.findByTenantIdAndStatus(5L, DpaSignatureStatus.SIGNED))
+        .thenReturn(List.of(signature(version.minusDays(2))));
+
+    // when / then
+    assertThat(tenantDpaService.isSignedForVersion(5L, version)).isFalse();
+  }
+
+  @Test
+  void getSignatures_Should_returnAllForTenant() {
+    // given
+    when(signatureRepository.findByTenantId(5L))
+        .thenReturn(List.of(signature(LocalDateTime.now())));
+
+    // when / then
+    assertThat(tenantDpaService.getSignatures(5L)).hasSize(1);
+  }
+
+  private TenantDpaSignatureEntity signature(LocalDateTime version) {
+    return TenantDpaSignatureEntity.builder()
+        .tenantId(5L)
+        .dpaVersion(version)
+        .status(DpaSignatureStatus.SIGNED)
+        .build();
+  }
+}

--- a/src/test/java/com/vi/tenantservice/api/service/TenantDpaServiceTest.java
+++ b/src/test/java/com/vi/tenantservice/api/service/TenantDpaServiceTest.java
@@ -1,6 +1,7 @@
 package com.vi.tenantservice.api.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -8,8 +9,10 @@ import static org.mockito.Mockito.when;
 import com.vi.tenantservice.api.model.DpaSignatureStatus;
 import com.vi.tenantservice.api.model.TenantDpaSignatureEntity;
 import com.vi.tenantservice.api.repository.TenantDpaSignatureRepository;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -80,6 +83,86 @@ class TenantDpaServiceTest {
 
     // when / then
     assertThat(tenantDpaService.getSignatures(5L)).hasSize(1);
+  }
+
+  @Test
+  void createSignInvite_Should_persistPendingRowWithHashedTokenAndExpiry_andReturnRawToken() {
+    // given
+    var version = LocalDateTime.now();
+    when(signatureRepository.save(any(TenantDpaSignatureEntity.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    // when
+    var rawToken = tenantDpaService.createSignInvite(7L, version, Duration.ofDays(14));
+
+    // then
+    assertThat(rawToken).isNotBlank();
+    var captor = ArgumentCaptor.forClass(TenantDpaSignatureEntity.class);
+    verify(signatureRepository).save(captor.capture());
+    var saved = captor.getValue();
+    assertThat(saved.getTenantId()).isEqualTo(7L);
+    assertThat(saved.getStatus()).isEqualTo(DpaSignatureStatus.PENDING);
+    assertThat(saved.getDpaVersion()).isEqualTo(version);
+    // the raw token is never stored — only its SHA-256 hash
+    assertThat(saved.getTokenHash()).isEqualTo(DpaSignToken.hash(rawToken)).isNotEqualTo(rawToken);
+    assertThat(saved.getTokenExpiresAt()).isAfter(LocalDateTime.now());
+  }
+
+  @Test
+  void confirmSignature_Should_markSigned_andConsumeToken_When_tokenValid() {
+    // given
+    var rawToken = "raw-token-value";
+    var pending =
+        TenantDpaSignatureEntity.builder()
+            .tenantId(7L)
+            .status(DpaSignatureStatus.PENDING)
+            .tokenHash(DpaSignToken.hash(rawToken))
+            .tokenExpiresAt(LocalDateTime.now().plusDays(1))
+            .build();
+    when(signatureRepository.findByTokenHashAndStatus(
+            DpaSignToken.hash(rawToken), DpaSignatureStatus.PENDING))
+        .thenReturn(Optional.of(pending));
+    when(signatureRepository.save(any(TenantDpaSignatureEntity.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    // when
+    var result =
+        tenantDpaService.confirmSignature(rawToken, "Erika M", "Geschäftsführerin", false, "de");
+
+    // then
+    assertThat(result.getStatus()).isEqualTo(DpaSignatureStatus.SIGNED);
+    assertThat(result.getSignerName()).isEqualTo("Erika M");
+    assertThat(result.getSignedAt()).isNotNull();
+    assertThat(result.getTokenHash()).isNull(); // consumed -> single use
+  }
+
+  @Test
+  void confirmSignature_Should_throw_When_tokenUnknownOrAlreadyUsed() {
+    // given
+    when(signatureRepository.findByTokenHashAndStatus(any(), any())).thenReturn(Optional.empty());
+
+    // when / then
+    assertThatThrownBy(() -> tenantDpaService.confirmSignature("bad", "n", "p", false, "de"))
+        .isInstanceOf(InvalidDpaSignTokenException.class);
+  }
+
+  @Test
+  void confirmSignature_Should_throw_When_tokenExpired() {
+    // given
+    var rawToken = "expired-token";
+    var pending =
+        TenantDpaSignatureEntity.builder()
+            .status(DpaSignatureStatus.PENDING)
+            .tokenHash(DpaSignToken.hash(rawToken))
+            .tokenExpiresAt(LocalDateTime.now().minusMinutes(1))
+            .build();
+    when(signatureRepository.findByTokenHashAndStatus(
+            DpaSignToken.hash(rawToken), DpaSignatureStatus.PENDING))
+        .thenReturn(Optional.of(pending));
+
+    // when / then
+    assertThatThrownBy(() -> tenantDpaService.confirmSignature(rawToken, "n", "p", false, "de"))
+        .isInstanceOf(InvalidDpaSignTokenException.class);
   }
 
   private TenantDpaSignatureEntity signature(LocalDateTime version) {


### PR DESCRIPTION
## ⚠️ Review-only — not merge-ready yet
Backend foundation + secure sign flow of the AVV / Legal EPIC #46. Admin endpoints (publish / list / invite / gate) + multilingual converter + OWASP sanitizer are still **outstanding** (see #46). Opened for early **CodeRabbit + @shazia-k** review, not for merge.

## What
- Tenant DPA content (`content_dpa` + activation date) + signature record `tenant_dpa_signature` (status, signer, FK to tenant)
- `TenantDpaService` — record / gate / list, plus a **secure single-use sign token**: 256-bit `SecureRandom`, SHA-256 hash at rest (raw token only in the link), expiry, and **atomic** consume via a conditional `UPDATE … WHERE token_hash=:h AND status=PENDING` (concurrent double-submit → exactly one winner)
- Public endpoint `POST /tenant/public/dpa/confirm/{token}` (permitAll — the token is the authorisation; an external signer without an account confirms via the link). 410 on unknown/used/expired; oversize input → 400
- Liquibase 0015 (DPA columns) / 0016 (signature table + FK) / 0017 (token columns)

## Review status
Adversarially reviewed by 3 agents (correctness / security / test-quality) and **hardened**: atomic single-use (race fixed), `@PrePersist` NOT-NULL defaults, `@Convert(NumericBooleanConverter)`, FK, input length bounds, null-token guard. Verdict: token design sound, no must-fix-now security hole. Full fix-list in #46 (comment).

## Open question for reviewers
**FK `ON DELETE CASCADE` vs `RESTRICT`** on `tenant_dpa_signature`: CASCADE destroys the signed-DPA audit trail when a tenant is deleted; RESTRICT preserves it but needs the delete workflow to clear signatures first. Currently **CASCADE** — opinions welcome.

## Tests
10 service + 4 repo (incl. a `@DataJpaTest` proving `consumeSignToken` signs once and rejects reuse) + 2 controller + 2 entity — all green (JDK 17).

Part of EPIC #46. Sibling PR: ORISO-AgencyService (Fachbereich DSE + Beratungszentrum address).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public DPA confirmation flow using a single-use link token.
  * Introduced DPA signature tracking, including signer details, status, timestamps, and language.
  * Added support for storing DPA content and its activation date on tenants.

* **Bug Fixes**
  * Expired, reused, or invalid confirmation tokens now return a clear failure response.
  * Confirmation is handled safely to prevent duplicate submissions.

* **Chores**
  * Updated database migrations and API schemas to include the new DPA-related capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->