### PR TITLE
AVV / Legal flow — admin DPA endpoints, version history, retention (part of #46)

### DIFF
--- a/api/tenantservice.yaml
+++ b/api/tenantservice.yaml
@@ -504,6 +504,42 @@ paths:
           description: CONFLICT - the tenant has no published DPA to sign yet
         500:
           description: INTERNAL SERVER ERROR - server encountered unexpected condition
+  /tenantadmin/{id}/dpa:
+    summary: 'Publish a tenant Data Processing Agreement (multilingual)'
+    put:
+      tags:
+        - tenant-controller
+      summary: 'Publishes the tenant DPA text and stamps a new version [Authorization: Authority.UPDATE_TENANT]'
+      operationId: publishDataProcessingAgreement
+      parameters:
+        - name: id
+          in: path
+          description: Tenant ID
+          required: true
+          schema:
+            type: long
+      requestBody:
+        required: true
+        description: 'Per-language DPA HTML content (language code -> HTML)'
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DpaGateStatusDTO'
+        403:
+          description: FORBIDDEN - not authorized to access this tenant
+        404:
+          description: NOT FOUND - tenant does not exist
+        500:
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
 components:
   schemas:
     DpaSignInviteDTO:

--- a/api/tenantservice.yaml
+++ b/api/tenantservice.yaml
@@ -540,8 +540,42 @@ paths:
           description: NOT FOUND - tenant does not exist
         500:
           description: INTERNAL SERVER ERROR - server encountered unexpected condition
+  /tenantadmin/{id}/dpa/versions:
+    summary: 'Published DPA versions of a tenant (newest first)'
+    get:
+      tags:
+        - tenant-controller
+      summary: 'Lists the published DPA versions of a tenant [Authorization: Authority.GET_TENANT]'
+      operationId: getDataProcessingAgreementVersions
+      parameters:
+        - name: id
+          in: path
+          description: Tenant ID
+          required: true
+          schema:
+            type: long
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DpaVersionDTO'
+        403:
+          description: FORBIDDEN - not authorized to access this tenant
+        500:
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
 components:
   schemas:
+    DpaVersionDTO:
+      type: object
+      properties:
+        activationDate:
+          type: string
+        content:
+          type: string
     DpaSignInviteDTO:
       type: object
       properties:

--- a/api/tenantservice.yaml
+++ b/api/tenantservice.yaml
@@ -425,8 +425,67 @@ paths:
           description: GONE - token unknown, already used, or expired
         500:
           description: INTERNAL SERVER ERROR - server encountered unexpected condition
+  /tenantadmin/{id}/dpa/signatures:
+    summary: 'Confirmed DPA signatures of a tenant (audit list)'
+    get:
+      tags:
+        - tenant-controller
+      summary: 'Lists the DPA confirmations of a tenant [Authorization: Authority.GET_TENANT]'
+      operationId: getDataProcessingAgreementSignatures
+      parameters:
+        - name: id
+          in: path
+          description: Tenant ID
+          required: true
+          schema:
+            type: long
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DpaSignatureDTO'
+        403:
+          description: FORBIDDEN - not authorized to access this tenant
+        500:
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
+  /tenantadmin/{id}/dpa/gate:
+    summary: 'DPA legal-gate status of a tenant'
+    get:
+      tags:
+        - tenant-controller
+      summary: 'Whether the tenant DPA is published and signed [Authorization: Authority.GET_TENANT]'
+      operationId: getDataProcessingAgreementGate
+      parameters:
+        - name: id
+          in: path
+          description: Tenant ID
+          required: true
+          schema:
+            type: long
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DpaGateStatusDTO'
+        403:
+          description: FORBIDDEN - not authorized to access this tenant
+        500:
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
 components:
   schemas:
+    DpaGateStatusDTO:
+      type: object
+      properties:
+        dpaPublished:
+          type: boolean
+        dpaSigned:
+          type: boolean
     DpaSignatureRequestDTO:
       type: object
       required:

--- a/api/tenantservice.yaml
+++ b/api/tenantservice.yaml
@@ -477,8 +477,44 @@ paths:
           description: FORBIDDEN - not authorized to access this tenant
         500:
           description: INTERNAL SERVER ERROR - server encountered unexpected condition
+  /tenantadmin/{id}/dpa/invite:
+    summary: 'Create a single-use DPA sign invite (link) for a tenant'
+    post:
+      tags:
+        - tenant-controller
+      summary: 'Creates a single-use sign link for a tenant DPA [Authorization: Authority.UPDATE_TENANT]'
+      operationId: createDataProcessingAgreementSignInvite
+      parameters:
+        - name: id
+          in: path
+          description: Tenant ID
+          required: true
+          schema:
+            type: long
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DpaSignInviteDTO'
+        403:
+          description: FORBIDDEN - not authorized to access this tenant
+        409:
+          description: CONFLICT - the tenant has no published DPA to sign yet
+        500:
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
 components:
   schemas:
+    DpaSignInviteDTO:
+      type: object
+      properties:
+        token:
+          type: string
+        signLink:
+          type: string
+        expiresAt:
+          type: string
     DpaGateStatusDTO:
       type: object
       properties:

--- a/src/main/java/com/vi/tenantservice/TenantServiceApplication.java
+++ b/src/main/java/com/vi/tenantservice/TenantServiceApplication.java
@@ -2,9 +2,11 @@ package com.vi.tenantservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 /** Starter class for the application. */
 @SpringBootApplication
+@EnableScheduling
 public class TenantServiceApplication {
 
   /**

--- a/src/main/java/com/vi/tenantservice/api/controller/TenantController.java
+++ b/src/main/java/com/vi/tenantservice/api/controller/TenantController.java
@@ -8,6 +8,7 @@ import com.vi.tenantservice.api.model.DpaGateStatusDTO;
 import com.vi.tenantservice.api.model.DpaSignInviteDTO;
 import com.vi.tenantservice.api.model.DpaSignatureDTO;
 import com.vi.tenantservice.api.model.DpaSignatureRequestDTO;
+import com.vi.tenantservice.api.model.DpaVersionDTO;
 import com.vi.tenantservice.api.model.MultilingualTenantDTO;
 import com.vi.tenantservice.api.model.RestrictedTenantDTO;
 import com.vi.tenantservice.api.model.TenantAdminControls;
@@ -91,6 +92,12 @@ public class TenantController implements TenantApi, TenantadminApi {
   @PreAuthorize("hasAuthority('AUTHORIZATION_GET_TENANT')")
   public ResponseEntity<DpaGateStatusDTO> getDataProcessingAgreementGate(Long id) {
     return new ResponseEntity<>(tenantDpaFacade.getGateStatus(id), HttpStatus.OK);
+  }
+
+  @Override
+  @PreAuthorize("hasAuthority('AUTHORIZATION_GET_TENANT')")
+  public ResponseEntity<List<DpaVersionDTO>> getDataProcessingAgreementVersions(Long id) {
+    return new ResponseEntity<>(tenantDpaFacade.getVersions(id), HttpStatus.OK);
   }
 
   @Override

--- a/src/main/java/com/vi/tenantservice/api/controller/TenantController.java
+++ b/src/main/java/com/vi/tenantservice/api/controller/TenantController.java
@@ -5,6 +5,7 @@ import com.vi.tenantservice.api.facade.TenantServiceFacade;
 import com.vi.tenantservice.api.model.AdminTenantDTO;
 import com.vi.tenantservice.api.model.BasicTenantLicensingDTO;
 import com.vi.tenantservice.api.model.DpaGateStatusDTO;
+import com.vi.tenantservice.api.model.DpaSignInviteDTO;
 import com.vi.tenantservice.api.model.DpaSignatureDTO;
 import com.vi.tenantservice.api.model.DpaSignatureRequestDTO;
 import com.vi.tenantservice.api.model.MultilingualTenantDTO;
@@ -12,6 +13,7 @@ import com.vi.tenantservice.api.model.RestrictedTenantDTO;
 import com.vi.tenantservice.api.model.TenantAdminControls;
 import com.vi.tenantservice.api.model.TenantDTO;
 import com.vi.tenantservice.api.model.TenantsSearchResultDTO;
+import com.vi.tenantservice.api.service.DpaNotPublishedException;
 import com.vi.tenantservice.api.service.InvalidDpaSignTokenException;
 import com.vi.tenantservice.api.service.TenantDpaService;
 import com.vi.tenantservice.config.security.AuthorisationService;
@@ -88,6 +90,18 @@ public class TenantController implements TenantApi, TenantadminApi {
   @PreAuthorize("hasAuthority('AUTHORIZATION_GET_TENANT')")
   public ResponseEntity<DpaGateStatusDTO> getDataProcessingAgreementGate(Long id) {
     return new ResponseEntity<>(tenantDpaFacade.getGateStatus(id), HttpStatus.OK);
+  }
+
+  @Override
+  @PreAuthorize("hasAuthority('AUTHORIZATION_UPDATE_TENANT')")
+  public ResponseEntity<DpaSignInviteDTO> createDataProcessingAgreementSignInvite(Long id) {
+    return new ResponseEntity<>(tenantDpaFacade.createSignInvite(id), HttpStatus.OK);
+  }
+
+  @ExceptionHandler(DpaNotPublishedException.class)
+  ResponseEntity<Void> handleDpaNotPublished(DpaNotPublishedException e) {
+    log.info("DPA sign invite rejected: {}", e.getMessage());
+    return new ResponseEntity<>(HttpStatus.CONFLICT);
   }
 
   @Override

--- a/src/main/java/com/vi/tenantservice/api/controller/TenantController.java
+++ b/src/main/java/com/vi/tenantservice/api/controller/TenantController.java
@@ -24,6 +24,7 @@ import jakarta.validation.Valid;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -96,6 +97,13 @@ public class TenantController implements TenantApi, TenantadminApi {
   @PreAuthorize("hasAuthority('AUTHORIZATION_UPDATE_TENANT')")
   public ResponseEntity<DpaSignInviteDTO> createDataProcessingAgreementSignInvite(Long id) {
     return new ResponseEntity<>(tenantDpaFacade.createSignInvite(id), HttpStatus.OK);
+  }
+
+  @Override
+  @PreAuthorize("hasAuthority('AUTHORIZATION_UPDATE_TENANT')")
+  public ResponseEntity<DpaGateStatusDTO> publishDataProcessingAgreement(
+      Long id, Map<String, String> requestBody) {
+    return new ResponseEntity<>(tenantDpaFacade.publishDpa(id, requestBody), HttpStatus.OK);
   }
 
   @ExceptionHandler(DpaNotPublishedException.class)

--- a/src/main/java/com/vi/tenantservice/api/controller/TenantController.java
+++ b/src/main/java/com/vi/tenantservice/api/controller/TenantController.java
@@ -1,8 +1,10 @@
 package com.vi.tenantservice.api.controller;
 
+import com.vi.tenantservice.api.facade.TenantDpaFacade;
 import com.vi.tenantservice.api.facade.TenantServiceFacade;
 import com.vi.tenantservice.api.model.AdminTenantDTO;
 import com.vi.tenantservice.api.model.BasicTenantLicensingDTO;
+import com.vi.tenantservice.api.model.DpaGateStatusDTO;
 import com.vi.tenantservice.api.model.DpaSignatureDTO;
 import com.vi.tenantservice.api.model.DpaSignatureRequestDTO;
 import com.vi.tenantservice.api.model.MultilingualTenantDTO;
@@ -45,6 +47,7 @@ public class TenantController implements TenantApi, TenantadminApi {
   private final @NonNull AuthorisationService authorisationService;
   private final @NonNull TenantDtoMapper tenantDtoMapper;
   private final @NonNull TenantDpaService tenantDpaService;
+  private final @NonNull TenantDpaFacade tenantDpaFacade;
 
   /**
    * Public DPA confirmation via a single-use sign token. No authentication: the token is the
@@ -73,6 +76,18 @@ public class TenantController implements TenantApi, TenantadminApi {
   ResponseEntity<Void> handleInvalidDpaSignToken(InvalidDpaSignTokenException e) {
     log.info("Rejected DPA sign attempt: {}", e.getMessage());
     return new ResponseEntity<>(HttpStatus.GONE);
+  }
+
+  @Override
+  @PreAuthorize("hasAuthority('AUTHORIZATION_GET_TENANT')")
+  public ResponseEntity<List<DpaSignatureDTO>> getDataProcessingAgreementSignatures(Long id) {
+    return new ResponseEntity<>(tenantDpaFacade.getSignatures(id), HttpStatus.OK);
+  }
+
+  @Override
+  @PreAuthorize("hasAuthority('AUTHORIZATION_GET_TENANT')")
+  public ResponseEntity<DpaGateStatusDTO> getDataProcessingAgreementGate(Long id) {
+    return new ResponseEntity<>(tenantDpaFacade.getGateStatus(id), HttpStatus.OK);
   }
 
   @Override

--- a/src/main/java/com/vi/tenantservice/api/facade/TenantDpaFacade.java
+++ b/src/main/java/com/vi/tenantservice/api/facade/TenantDpaFacade.java
@@ -1,14 +1,19 @@
 package com.vi.tenantservice.api.facade;
 
 import com.vi.tenantservice.api.model.DpaGateStatusDTO;
+import com.vi.tenantservice.api.model.DpaSignInviteDTO;
 import com.vi.tenantservice.api.model.DpaSignatureDTO;
 import com.vi.tenantservice.api.model.TenantDpaSignatureEntity;
 import com.vi.tenantservice.api.model.TenantEntity;
+import com.vi.tenantservice.api.service.DpaNotPublishedException;
 import com.vi.tenantservice.api.service.TenantDpaService;
 import com.vi.tenantservice.api.service.TenantService;
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 /**
@@ -22,9 +27,42 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TenantDpaFacade {
 
+  private static final Duration INVITE_TTL = Duration.ofDays(14);
+
   private final @NonNull TenantDpaService tenantDpaService;
   private final @NonNull TenantFacadeAuthorisationService tenantFacadeAuthorisationService;
   private final @NonNull TenantService tenantService;
+
+  @Value("${app.base.url:}")
+  private String appBaseUrl;
+
+  /**
+   * Creates a single-use sign invite for the tenant's currently published DPA and returns the raw
+   * token plus a user-facing sign link. Requires a published DPA (an activation date).
+   *
+   * @throws DpaNotPublishedException if the tenant has not published a DPA yet.
+   */
+  public DpaSignInviteDTO createSignInvite(Long tenantId) {
+    tenantFacadeAuthorisationService.assertUserIsAuthorizedToAccessTenant(tenantId);
+    var version =
+        tenantService
+            .findTenantById(tenantId)
+            .map(TenantEntity::getContentDataProcessingAgreementActivationDate)
+            .orElse(null);
+    if (version == null) {
+      throw new DpaNotPublishedException(
+          "Tenant " + tenantId + " has no published DPA to sign yet");
+    }
+    var rawToken = tenantDpaService.createSignInvite(tenantId, version, INVITE_TTL);
+    return new DpaSignInviteDTO()
+        .token(rawToken)
+        .signLink(buildSignLink(rawToken))
+        .expiresAt(LocalDateTime.now().plus(INVITE_TTL).toString());
+  }
+
+  private String buildSignLink(String rawToken) {
+    return (appBaseUrl == null ? "" : appBaseUrl) + "/dpa-sign/" + rawToken;
+  }
 
   /** The tenant's confirmed-DPA audit list (the platform-admin "list of confirmed AVVs"). */
   public List<DpaSignatureDTO> getSignatures(Long tenantId) {

--- a/src/main/java/com/vi/tenantservice/api/facade/TenantDpaFacade.java
+++ b/src/main/java/com/vi/tenantservice/api/facade/TenantDpaFacade.java
@@ -14,6 +14,7 @@ import com.vi.tenantservice.api.util.JsonConverter;
 import com.vi.tenantservice.api.validation.InputSanitizer;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -22,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 /**
@@ -98,6 +100,7 @@ public class TenantDpaFacade {
    * version). Returns the resulting gate status (published; signed is false until the new version
    * is confirmed).
    */
+  @Transactional
   public DpaGateStatusDTO publishDpa(Long tenantId, Map<String, String> contentByLanguage) {
     tenantFacadeAuthorisationService.assertUserIsAuthorizedToAccessTenant(tenantId);
     var tenant =
@@ -111,7 +114,9 @@ public class TenantDpaFacade {
           (lang, html) ->
               sanitized.put(lang, inputSanitizer.sanitizeAllowingFormattingAndLinks(html)));
     }
-    var version = LocalDateTime.now();
+    // Truncate to seconds so the in-memory version key matches the MariaDB DATETIME(0) column
+    // after a round-trip — otherwise the signature gate (equals on dpa_version) could never match.
+    var version = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
     var json = JsonConverter.convertToJson(sanitized);
     tenant.setContentDataProcessingAgreement(json);
     tenant.setContentDataProcessingAgreementActivationDate(version);

--- a/src/main/java/com/vi/tenantservice/api/facade/TenantDpaFacade.java
+++ b/src/main/java/com/vi/tenantservice/api/facade/TenantDpaFacade.java
@@ -1,0 +1,55 @@
+package com.vi.tenantservice.api.facade;
+
+import com.vi.tenantservice.api.model.DpaGateStatusDTO;
+import com.vi.tenantservice.api.model.DpaSignatureDTO;
+import com.vi.tenantservice.api.model.TenantDpaSignatureEntity;
+import com.vi.tenantservice.api.model.TenantEntity;
+import com.vi.tenantservice.api.service.TenantDpaService;
+import com.vi.tenantservice.api.service.TenantService;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * Tenant-scoped, authorisation-guarded entry point for the admin-facing DPA queries. Every method
+ * runs {@link TenantFacadeAuthorisationService#assertUserIsAuthorizedToAccessTenant} first, so a
+ * single-tenant admin can only ever see their own tenant's data — this is the IDOR guard the
+ * security review required (the underlying {@link TenantDpaService} takes a raw tenant id and must
+ * never be exposed without it).
+ */
+@Service
+@RequiredArgsConstructor
+public class TenantDpaFacade {
+
+  private final @NonNull TenantDpaService tenantDpaService;
+  private final @NonNull TenantFacadeAuthorisationService tenantFacadeAuthorisationService;
+  private final @NonNull TenantService tenantService;
+
+  /** The tenant's confirmed-DPA audit list (the platform-admin "list of confirmed AVVs"). */
+  public List<DpaSignatureDTO> getSignatures(Long tenantId) {
+    tenantFacadeAuthorisationService.assertUserIsAuthorizedToAccessTenant(tenantId);
+    return tenantDpaService.getSignatures(tenantId).stream().map(TenantDpaFacade::toDto).toList();
+  }
+
+  /** Whether the tenant's DPA is published and signed (the consultation gate). */
+  public DpaGateStatusDTO getGateStatus(Long tenantId) {
+    tenantFacadeAuthorisationService.assertUserIsAuthorizedToAccessTenant(tenantId);
+    var version =
+        tenantService
+            .findTenantById(tenantId)
+            .map(TenantEntity::getContentDataProcessingAgreementActivationDate)
+            .orElse(null);
+    boolean published = version != null;
+    boolean signed = published && tenantDpaService.isSignedForVersion(tenantId, version);
+    return new DpaGateStatusDTO().dpaPublished(published).dpaSigned(signed);
+  }
+
+  private static DpaSignatureDTO toDto(TenantDpaSignatureEntity entity) {
+    return new DpaSignatureDTO()
+        .tenantId(entity.getTenantId())
+        .status(entity.getStatus() == null ? null : entity.getStatus().name())
+        .signerName(entity.getSignerName())
+        .signedAt(entity.getSignedAt() == null ? null : entity.getSignedAt().toString());
+  }
+}

--- a/src/main/java/com/vi/tenantservice/api/facade/TenantDpaFacade.java
+++ b/src/main/java/com/vi/tenantservice/api/facade/TenantDpaFacade.java
@@ -3,7 +3,9 @@ package com.vi.tenantservice.api.facade;
 import com.vi.tenantservice.api.model.DpaGateStatusDTO;
 import com.vi.tenantservice.api.model.DpaSignInviteDTO;
 import com.vi.tenantservice.api.model.DpaSignatureDTO;
+import com.vi.tenantservice.api.model.DpaVersionDTO;
 import com.vi.tenantservice.api.model.TenantDpaSignatureEntity;
+import com.vi.tenantservice.api.model.TenantDpaVersionEntity;
 import com.vi.tenantservice.api.model.TenantEntity;
 import com.vi.tenantservice.api.service.DpaNotPublishedException;
 import com.vi.tenantservice.api.service.TenantDpaService;
@@ -110,11 +112,28 @@ public class TenantDpaFacade {
               sanitized.put(lang, inputSanitizer.sanitizeAllowingFormattingAndLinks(html)));
     }
     var version = LocalDateTime.now();
-    tenant.setContentDataProcessingAgreement(JsonConverter.convertToJson(sanitized));
+    var json = JsonConverter.convertToJson(sanitized);
+    tenant.setContentDataProcessingAgreement(json);
     tenant.setContentDataProcessingAgreementActivationDate(version);
     tenantService.update(tenant);
+    tenantDpaService.recordPublishedVersion(tenantId, json, version);
     boolean signed = tenantDpaService.isSignedForVersion(tenantId, version);
     return new DpaGateStatusDTO().dpaPublished(true).dpaSigned(signed);
+  }
+
+  /** The tenant's published DPA versions (newest first) for the read-only "look back" viewer. */
+  public List<DpaVersionDTO> getVersions(Long tenantId) {
+    tenantFacadeAuthorisationService.assertUserIsAuthorizedToAccessTenant(tenantId);
+    return tenantDpaService.getVersions(tenantId).stream()
+        .map(TenantDpaFacade::toVersionDto)
+        .toList();
+  }
+
+  private static DpaVersionDTO toVersionDto(TenantDpaVersionEntity entity) {
+    return new DpaVersionDTO()
+        .activationDate(
+            entity.getActivationDate() == null ? null : entity.getActivationDate().toString())
+        .content(entity.getContent());
   }
 
   private static DpaSignatureDTO toDto(TenantDpaSignatureEntity entity) {

--- a/src/main/java/com/vi/tenantservice/api/facade/TenantDpaFacade.java
+++ b/src/main/java/com/vi/tenantservice/api/facade/TenantDpaFacade.java
@@ -8,13 +8,19 @@ import com.vi.tenantservice.api.model.TenantEntity;
 import com.vi.tenantservice.api.service.DpaNotPublishedException;
 import com.vi.tenantservice.api.service.TenantDpaService;
 import com.vi.tenantservice.api.service.TenantService;
+import com.vi.tenantservice.api.util.JsonConverter;
+import com.vi.tenantservice.api.validation.InputSanitizer;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 /**
  * Tenant-scoped, authorisation-guarded entry point for the admin-facing DPA queries. Every method
@@ -32,6 +38,7 @@ public class TenantDpaFacade {
   private final @NonNull TenantDpaService tenantDpaService;
   private final @NonNull TenantFacadeAuthorisationService tenantFacadeAuthorisationService;
   private final @NonNull TenantService tenantService;
+  private final @NonNull InputSanitizer inputSanitizer;
 
   @Value("${app.base.url:}")
   private String appBaseUrl;
@@ -81,6 +88,33 @@ public class TenantDpaFacade {
     boolean published = version != null;
     boolean signed = published && tenantDpaService.isSignedForVersion(tenantId, version);
     return new DpaGateStatusDTO().dpaPublished(published).dpaSigned(signed);
+  }
+
+  /**
+   * Publishes the tenant's DPA: sanitises each per-language HTML translation (OWASP allowlist),
+   * stores it as the multilingual JSON content, and stamps a fresh activation date (= new contract
+   * version). Returns the resulting gate status (published; signed is false until the new version
+   * is confirmed).
+   */
+  public DpaGateStatusDTO publishDpa(Long tenantId, Map<String, String> contentByLanguage) {
+    tenantFacadeAuthorisationService.assertUserIsAuthorizedToAccessTenant(tenantId);
+    var tenant =
+        tenantService
+            .findTenantById(tenantId)
+            .orElseThrow(
+                () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Tenant not found"));
+    var sanitized = new LinkedHashMap<String, String>();
+    if (contentByLanguage != null) {
+      contentByLanguage.forEach(
+          (lang, html) ->
+              sanitized.put(lang, inputSanitizer.sanitizeAllowingFormattingAndLinks(html)));
+    }
+    var version = LocalDateTime.now();
+    tenant.setContentDataProcessingAgreement(JsonConverter.convertToJson(sanitized));
+    tenant.setContentDataProcessingAgreementActivationDate(version);
+    tenantService.update(tenant);
+    boolean signed = tenantDpaService.isSignedForVersion(tenantId, version);
+    return new DpaGateStatusDTO().dpaPublished(true).dpaSigned(signed);
   }
 
   private static DpaSignatureDTO toDto(TenantDpaSignatureEntity entity) {

--- a/src/main/java/com/vi/tenantservice/api/model/TenantDpaVersionEntity.java
+++ b/src/main/java/com/vi/tenantservice/api/model/TenantDpaVersionEntity.java
@@ -1,0 +1,63 @@
+package com.vi.tenantservice.api.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * An immutable snapshot of a published DPA version. One row is written every time a tenant
+ * publishes its DPA, so the admin UI can offer a lightweight "look back" at earlier wordings (the
+ * tenant table only keeps the current content). Intentionally simple: append-only, never edited.
+ */
+@Entity
+@Table(name = "tenant_dpa_version")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+public class TenantDpaVersionEntity {
+
+  @Id
+  @SequenceGenerator(
+      name = "dpa_version_id_seq",
+      allocationSize = 1,
+      sequenceName = "SEQUENCE_TENANT_DPA_VERSION")
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "dpa_version_id_seq")
+  @Column(name = "id", updatable = false, nullable = false)
+  private Long id;
+
+  @Column(name = "tenant_id", nullable = false)
+  private Long tenantId;
+
+  /** The published multilingual content (JSON map language -> HTML), as stored at that version. */
+  @Column(name = "content")
+  private String content;
+
+  /**
+   * The activation timestamp that identifies this version (matches the tenant's at publish time).
+   */
+  @Column(name = "activation_date", nullable = false)
+  private LocalDateTime activationDate;
+
+  @Column(name = "create_date", nullable = false)
+  private LocalDateTime createDate;
+
+  @PrePersist
+  void applyDefaults() {
+    if (createDate == null) {
+      createDate = LocalDateTime.now();
+    }
+  }
+}

--- a/src/main/java/com/vi/tenantservice/api/repository/TenantDpaSignatureRepository.java
+++ b/src/main/java/com/vi/tenantservice/api/repository/TenantDpaSignatureRepository.java
@@ -20,6 +20,9 @@ public interface TenantDpaSignatureRepository
   Optional<TenantDpaSignatureEntity> findByTokenHashAndStatus(
       String tokenHash, DpaSignatureStatus status);
 
+  /** Retention purge: removes signatures of a given status created before the cutoff. */
+  long deleteByStatusAndCreateDateBefore(DpaSignatureStatus status, LocalDateTime cutoff);
+
   /**
    * Atomically consumes a PENDING sign token: flips it to SIGNED, records the signer, and clears
    * the token — all in one conditional UPDATE. Only the row that is still PENDING is affected, so

--- a/src/main/java/com/vi/tenantservice/api/repository/TenantDpaVersionRepository.java
+++ b/src/main/java/com/vi/tenantservice/api/repository/TenantDpaVersionRepository.java
@@ -1,0 +1,11 @@
+package com.vi.tenantservice.api.repository;
+
+import com.vi.tenantservice.api.model.TenantDpaVersionEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TenantDpaVersionRepository extends JpaRepository<TenantDpaVersionEntity, Long> {
+
+  /** Published versions for a tenant, newest first (so the UI can default to the latest). */
+  List<TenantDpaVersionEntity> findByTenantIdOrderByActivationDateDesc(Long tenantId);
+}

--- a/src/main/java/com/vi/tenantservice/api/service/DpaNotPublishedException.java
+++ b/src/main/java/com/vi/tenantservice/api/service/DpaNotPublishedException.java
@@ -1,0 +1,9 @@
+package com.vi.tenantservice.api.service;
+
+/** Thrown when a DPA sign invite is requested for a tenant that has not published its DPA yet. */
+public class DpaNotPublishedException extends RuntimeException {
+
+  public DpaNotPublishedException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/vi/tenantservice/api/service/TenantDpaRetentionService.java
+++ b/src/main/java/com/vi/tenantservice/api/service/TenantDpaRetentionService.java
@@ -1,0 +1,44 @@
+package com.vi.tenantservice.api.service;
+
+import com.vi.tenantservice.api.model.DpaSignatureStatus;
+import com.vi.tenantservice.api.repository.TenantDpaSignatureRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Retention for DENIED DPA confirmations: when a tenant refuses/denies its DPA the record is kept
+ * for a window and then auto-purged (the flow's "denied → deleted after 365 days"). Runs daily; the
+ * window and cron are configurable.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class TenantDpaRetentionService {
+
+  private final TenantDpaSignatureRepository signatureRepository;
+
+  @Value("${dpa.denied-retention-days:365}")
+  private long deniedRetentionDays;
+
+  /** Deletes DENIED signatures older than the retention window. Returns the number removed. */
+  @Transactional
+  public long purgeExpiredDeniedSignatures() {
+    var cutoff = LocalDateTime.now().minusDays(deniedRetentionDays);
+    long removed =
+        signatureRepository.deleteByStatusAndCreateDateBefore(DpaSignatureStatus.DENIED, cutoff);
+    if (removed > 0) {
+      log.info("DPA retention: purged {} DENIED signatures older than {}", removed, cutoff);
+    }
+    return removed;
+  }
+
+  @Scheduled(cron = "${dpa.retention-purge-cron:0 0 3 * * *}")
+  void scheduledPurge() {
+    purgeExpiredDeniedSignatures();
+  }
+}

--- a/src/main/java/com/vi/tenantservice/api/service/TenantDpaRetentionService.java
+++ b/src/main/java/com/vi/tenantservice/api/service/TenantDpaRetentionService.java
@@ -28,7 +28,10 @@ public class TenantDpaRetentionService {
   /** Deletes DENIED signatures older than the retention window. Returns the number removed. */
   @Transactional
   public long purgeExpiredDeniedSignatures() {
-    var cutoff = LocalDateTime.now().minusDays(deniedRetentionDays);
+    // floor at 1 day: a misconfigured 0/negative window must never purge all (or future) DENIED
+    // rows
+    var effectiveDays = Math.max(1L, deniedRetentionDays);
+    var cutoff = LocalDateTime.now().minusDays(effectiveDays);
     long removed =
         signatureRepository.deleteByStatusAndCreateDateBefore(DpaSignatureStatus.DENIED, cutoff);
     if (removed > 0) {
@@ -37,7 +40,13 @@ public class TenantDpaRetentionService {
     return removed;
   }
 
+  /**
+   * Scheduled entry point. {@code @Transactional} lives here (not only on {@link
+   * #purgeExpiredDeniedSignatures()}) because the scheduler self-invokes and self-invocation does
+   * not pass through the Spring proxy — so the transaction would otherwise be inert on this path.
+   */
   @Scheduled(cron = "${dpa.retention-purge-cron:0 0 3 * * *}")
+  @Transactional
   void scheduledPurge() {
     purgeExpiredDeniedSignatures();
   }

--- a/src/main/java/com/vi/tenantservice/api/service/TenantDpaService.java
+++ b/src/main/java/com/vi/tenantservice/api/service/TenantDpaService.java
@@ -2,7 +2,9 @@ package com.vi.tenantservice.api.service;
 
 import com.vi.tenantservice.api.model.DpaSignatureStatus;
 import com.vi.tenantservice.api.model.TenantDpaSignatureEntity;
+import com.vi.tenantservice.api.model.TenantDpaVersionEntity;
 import com.vi.tenantservice.api.repository.TenantDpaSignatureRepository;
+import com.vi.tenantservice.api.repository.TenantDpaVersionRepository;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -26,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class TenantDpaService {
 
   private final TenantDpaSignatureRepository signatureRepository;
+  private final TenantDpaVersionRepository versionRepository;
 
   /** Persists a SIGNED confirmation of the given DPA version for a tenant. */
   public TenantDpaSignatureEntity recordSignature(
@@ -62,6 +65,22 @@ public class TenantDpaService {
   /** All confirmations for a tenant (for the platform-admin list of confirmed AVVs). */
   public List<TenantDpaSignatureEntity> getSignatures(Long tenantId) {
     return signatureRepository.findByTenantId(tenantId);
+  }
+
+  /** Appends a published-version snapshot (called on every publish) for the "look back" history. */
+  public void recordPublishedVersion(Long tenantId, String content, LocalDateTime activationDate) {
+    versionRepository.save(
+        TenantDpaVersionEntity.builder()
+            .tenantId(tenantId)
+            .content(content)
+            .activationDate(activationDate)
+            .createDate(LocalDateTime.now())
+            .build());
+  }
+
+  /** Published DPA versions for a tenant, newest first. */
+  public List<TenantDpaVersionEntity> getVersions(Long tenantId) {
+    return versionRepository.findByTenantIdOrderByActivationDateDesc(tenantId);
   }
 
   /**

--- a/src/main/resources/db/changelog/changeset/0018_tenant_dpa_version/0018-changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0018_tenant_dpa_version/0018-changeSet.xml
@@ -1,0 +1,9 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+    <changeSet author="oriso" id="createTenantDpaVersion">
+        <sqlFile path="db/changelog/changeset/0018_tenant_dpa_version/createTenantDpaVersion.sql" stripComments="true" />
+        <rollback>
+            <sqlFile path="db/changelog/changeset/0018_tenant_dpa_version/createTenantDpaVersion-rollback.sql" stripComments="true" />
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0018_tenant_dpa_version/createTenantDpaVersion-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0018_tenant_dpa_version/createTenantDpaVersion-rollback.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS `tenantservice`.`tenant_dpa_version`;
+DROP SEQUENCE IF EXISTS `tenantservice`.`SEQUENCE_TENANT_DPA_VERSION`;

--- a/src/main/resources/db/changelog/changeset/0018_tenant_dpa_version/createTenantDpaVersion.sql
+++ b/src/main/resources/db/changelog/changeset/0018_tenant_dpa_version/createTenantDpaVersion.sql
@@ -1,0 +1,13 @@
+CREATE SEQUENCE IF NOT EXISTS `tenantservice`.`SEQUENCE_TENANT_DPA_VERSION` START WITH 100000 INCREMENT BY 1;
+
+CREATE TABLE IF NOT EXISTS `tenantservice`.`tenant_dpa_version` (
+    id bigint NOT NULL,
+    tenant_id bigint NOT NULL,
+    content longtext NULL,
+    activation_date datetime NOT NULL,
+    create_date datetime NOT NULL,
+    PRIMARY KEY (id),
+    KEY idx_tenant_dpa_version_tenant (tenant_id),
+    CONSTRAINT fk_tenant_dpa_version_tenant FOREIGN KEY (tenant_id)
+        REFERENCES `tenantservice`.`tenant` (id) ON DELETE CASCADE
+);

--- a/src/main/resources/db/changelog/tenantservice-dev-master.xml
+++ b/src/main/resources/db/changelog/tenantservice-dev-master.xml
@@ -24,4 +24,5 @@
   <include file="db/changelog/changeset/0015_add_tenant_dpa/0015-changeSet.xml"/>
   <include file="db/changelog/changeset/0016_tenant_dpa_signature/0016-changeSet.xml"/>
   <include file="db/changelog/changeset/0017_tenant_dpa_signature_token/0017-changeSet.xml"/>
+  <include file="db/changelog/changeset/0018_tenant_dpa_version/0018-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenantservice-local-master.xml
+++ b/src/main/resources/db/changelog/tenantservice-local-master.xml
@@ -24,4 +24,5 @@
 	<include file="db/changelog/changeset/0015_add_tenant_dpa/0015-changeSet.xml"/>
 	<include file="db/changelog/changeset/0016_tenant_dpa_signature/0016-changeSet.xml"/>
 	<include file="db/changelog/changeset/0017_tenant_dpa_signature_token/0017-changeSet.xml"/>
+	<include file="db/changelog/changeset/0018_tenant_dpa_version/0018-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenantservice-prod-master.xml
+++ b/src/main/resources/db/changelog/tenantservice-prod-master.xml
@@ -21,4 +21,5 @@
   <include file="db/changelog/changeset/0015_add_tenant_dpa/0015-changeSet.xml"/>
   <include file="db/changelog/changeset/0016_tenant_dpa_signature/0016-changeSet.xml"/>
   <include file="db/changelog/changeset/0017_tenant_dpa_signature_token/0017-changeSet.xml"/>
+  <include file="db/changelog/changeset/0018_tenant_dpa_version/0018-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenantservice-staging-master.xml
+++ b/src/main/resources/db/changelog/tenantservice-staging-master.xml
@@ -21,4 +21,5 @@
   <include file="db/changelog/changeset/0015_add_tenant_dpa/0015-changeSet.xml"/>
   <include file="db/changelog/changeset/0016_tenant_dpa_signature/0016-changeSet.xml"/>
   <include file="db/changelog/changeset/0017_tenant_dpa_signature_token/0017-changeSet.xml"/>
+  <include file="db/changelog/changeset/0018_tenant_dpa_version/0018-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/test/java/com/vi/tenantservice/api/controller/TenantControllerDpaConfirmTest.java
+++ b/src/test/java/com/vi/tenantservice/api/controller/TenantControllerDpaConfirmTest.java
@@ -6,10 +6,12 @@ import static org.mockito.Mockito.when;
 import com.vi.tenantservice.api.facade.TenantDpaFacade;
 import com.vi.tenantservice.api.facade.TenantServiceFacade;
 import com.vi.tenantservice.api.model.DpaGateStatusDTO;
+import com.vi.tenantservice.api.model.DpaSignInviteDTO;
 import com.vi.tenantservice.api.model.DpaSignatureDTO;
 import com.vi.tenantservice.api.model.DpaSignatureRequestDTO;
 import com.vi.tenantservice.api.model.DpaSignatureStatus;
 import com.vi.tenantservice.api.model.TenantDpaSignatureEntity;
+import com.vi.tenantservice.api.service.DpaNotPublishedException;
 import com.vi.tenantservice.api.service.InvalidDpaSignTokenException;
 import com.vi.tenantservice.api.service.TenantDpaService;
 import com.vi.tenantservice.config.security.AuthorisationService;
@@ -101,5 +103,33 @@ class TenantControllerDpaConfirmTest {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(response.getBody().getDpaPublished()).isTrue();
     assertThat(response.getBody().getDpaSigned()).isFalse();
+  }
+
+  @Test
+  void createDataProcessingAgreementSignInvite_Should_returnOkWithInvite() {
+    // given
+    when(tenantDpaFacade.createSignInvite(7L))
+        .thenReturn(
+            new DpaSignInviteDTO()
+                .token("T")
+                .signLink("/dpa-sign/T")
+                .expiresAt("2026-07-15T00:00"));
+
+    // when
+    var response = controller.createDataProcessingAgreementSignInvite(7L);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().getToken()).isEqualTo("T");
+    assertThat(response.getBody().getSignLink()).isEqualTo("/dpa-sign/T");
+  }
+
+  @Test
+  void handleDpaNotPublished_Should_return409Conflict() {
+    // when
+    var response = controller.handleDpaNotPublished(new DpaNotPublishedException("not published"));
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
   }
 }

--- a/src/test/java/com/vi/tenantservice/api/controller/TenantControllerDpaConfirmTest.java
+++ b/src/test/java/com/vi/tenantservice/api/controller/TenantControllerDpaConfirmTest.java
@@ -12,6 +12,7 @@ import com.vi.tenantservice.api.model.DpaSignInviteDTO;
 import com.vi.tenantservice.api.model.DpaSignatureDTO;
 import com.vi.tenantservice.api.model.DpaSignatureRequestDTO;
 import com.vi.tenantservice.api.model.DpaSignatureStatus;
+import com.vi.tenantservice.api.model.DpaVersionDTO;
 import com.vi.tenantservice.api.model.TenantDpaSignatureEntity;
 import com.vi.tenantservice.api.service.DpaNotPublishedException;
 import com.vi.tenantservice.api.service.InvalidDpaSignTokenException;
@@ -148,5 +149,21 @@ class TenantControllerDpaConfirmTest {
     // then
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(response.getBody().getDpaPublished()).isTrue();
+  }
+
+  @Test
+  void getDataProcessingAgreementVersions_Should_returnOkWithFacadeList() {
+    // given
+    when(tenantDpaFacade.getVersions(7L))
+        .thenReturn(
+            List.of(
+                new DpaVersionDTO().activationDate("2026-07-13T10:22").content("{\"de\":\"x\"}")));
+
+    // when
+    var response = controller.getDataProcessingAgreementVersions(7L);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).hasSize(1);
   }
 }

--- a/src/test/java/com/vi/tenantservice/api/controller/TenantControllerDpaConfirmTest.java
+++ b/src/test/java/com/vi/tenantservice/api/controller/TenantControllerDpaConfirmTest.java
@@ -3,7 +3,10 @@ package com.vi.tenantservice.api.controller;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import com.vi.tenantservice.api.facade.TenantDpaFacade;
 import com.vi.tenantservice.api.facade.TenantServiceFacade;
+import com.vi.tenantservice.api.model.DpaGateStatusDTO;
+import com.vi.tenantservice.api.model.DpaSignatureDTO;
 import com.vi.tenantservice.api.model.DpaSignatureRequestDTO;
 import com.vi.tenantservice.api.model.DpaSignatureStatus;
 import com.vi.tenantservice.api.model.TenantDpaSignatureEntity;
@@ -11,6 +14,7 @@ import com.vi.tenantservice.api.service.InvalidDpaSignTokenException;
 import com.vi.tenantservice.api.service.TenantDpaService;
 import com.vi.tenantservice.config.security.AuthorisationService;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -25,6 +29,7 @@ class TenantControllerDpaConfirmTest {
   @Mock private AuthorisationService authorisationService;
   @Mock private TenantDtoMapper tenantDtoMapper;
   @Mock private TenantDpaService tenantDpaService;
+  @Mock private TenantDpaFacade tenantDpaFacade;
   @InjectMocks private TenantController controller;
 
   @Test
@@ -66,5 +71,35 @@ class TenantControllerDpaConfirmTest {
 
     // then
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.GONE);
+  }
+
+  @Test
+  void getDataProcessingAgreementSignatures_Should_returnOkWithFacadeList() {
+    // given
+    when(tenantDpaFacade.getSignatures(7L))
+        .thenReturn(
+            List.of(new DpaSignatureDTO().tenantId(7L).status("SIGNED").signerName("Erika")));
+
+    // when
+    var response = controller.getDataProcessingAgreementSignatures(7L);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).hasSize(1);
+  }
+
+  @Test
+  void getDataProcessingAgreementGate_Should_returnOkWithFacadeStatus() {
+    // given
+    when(tenantDpaFacade.getGateStatus(7L))
+        .thenReturn(new DpaGateStatusDTO().dpaPublished(true).dpaSigned(false));
+
+    // when
+    var response = controller.getDataProcessingAgreementGate(7L);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().getDpaPublished()).isTrue();
+    assertThat(response.getBody().getDpaSigned()).isFalse();
   }
 }

--- a/src/test/java/com/vi/tenantservice/api/controller/TenantControllerDpaConfirmTest.java
+++ b/src/test/java/com/vi/tenantservice/api/controller/TenantControllerDpaConfirmTest.java
@@ -1,6 +1,8 @@
 package com.vi.tenantservice.api.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import com.vi.tenantservice.api.facade.TenantDpaFacade;
@@ -17,6 +19,7 @@ import com.vi.tenantservice.api.service.TenantDpaService;
 import com.vi.tenantservice.config.security.AuthorisationService;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -131,5 +134,19 @@ class TenantControllerDpaConfirmTest {
 
     // then
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+  }
+
+  @Test
+  void publishDataProcessingAgreement_Should_returnOkWithGate() {
+    // given
+    when(tenantDpaFacade.publishDpa(eq(7L), any()))
+        .thenReturn(new DpaGateStatusDTO().dpaPublished(true).dpaSigned(false));
+
+    // when
+    var response = controller.publishDataProcessingAgreement(7L, Map.of("de", "<p>x</p>"));
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().getDpaPublished()).isTrue();
   }
 }

--- a/src/test/java/com/vi/tenantservice/api/facade/TenantDpaFacadeTest.java
+++ b/src/test/java/com/vi/tenantservice/api/facade/TenantDpaFacadeTest.java
@@ -16,8 +16,10 @@ import com.vi.tenantservice.api.model.TenantEntity;
 import com.vi.tenantservice.api.service.DpaNotPublishedException;
 import com.vi.tenantservice.api.service.TenantDpaService;
 import com.vi.tenantservice.api.service.TenantService;
+import com.vi.tenantservice.api.validation.InputSanitizer;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +34,7 @@ class TenantDpaFacadeTest {
   @Mock private TenantDpaService tenantDpaService;
   @Mock private TenantFacadeAuthorisationService tenantFacadeAuthorisationService;
   @Mock private TenantService tenantService;
+  @Mock private InputSanitizer inputSanitizer;
   @InjectMocks private TenantDpaFacade tenantDpaFacade;
 
   @Test
@@ -129,5 +132,24 @@ class TenantDpaFacadeTest {
     assertThatThrownBy(() -> tenantDpaFacade.createSignInvite(5L))
         .isInstanceOf(DpaNotPublishedException.class);
     verify(tenantDpaService, never()).createSignInvite(any(), any(), any());
+  }
+
+  @Test
+  void publishDpa_Should_sanitize_storeAsJson_stampVersion_andReturnGate() {
+    // given
+    var tenant = new TenantEntity();
+    when(tenantService.findTenantById(5L)).thenReturn(Optional.of(tenant));
+    when(inputSanitizer.sanitizeAllowingFormattingAndLinks("<p>x</p>")).thenReturn("<p>clean</p>");
+
+    // when
+    var status = tenantDpaFacade.publishDpa(5L, Map.of("de", "<p>x</p>"));
+
+    // then
+    verify(tenantFacadeAuthorisationService).assertUserIsAuthorizedToAccessTenant(5L);
+    assertThat(tenant.getContentDataProcessingAgreement()).contains("clean");
+    assertThat(tenant.getContentDataProcessingAgreementActivationDate()).isNotNull();
+    verify(tenantService).update(tenant);
+    assertThat(status.getDpaPublished()).isTrue();
+    assertThat(status.getDpaSigned()).isFalse();
   }
 }

--- a/src/test/java/com/vi/tenantservice/api/facade/TenantDpaFacadeTest.java
+++ b/src/test/java/com/vi/tenantservice/api/facade/TenantDpaFacadeTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import com.vi.tenantservice.api.model.DpaSignatureStatus;
 import com.vi.tenantservice.api.model.TenantDpaSignatureEntity;
+import com.vi.tenantservice.api.model.TenantDpaVersionEntity;
 import com.vi.tenantservice.api.model.TenantEntity;
 import com.vi.tenantservice.api.service.DpaNotPublishedException;
 import com.vi.tenantservice.api.service.TenantDpaService;
@@ -149,7 +150,29 @@ class TenantDpaFacadeTest {
     assertThat(tenant.getContentDataProcessingAgreement()).contains("clean");
     assertThat(tenant.getContentDataProcessingAgreementActivationDate()).isNotNull();
     verify(tenantService).update(tenant);
+    verify(tenantDpaService).recordPublishedVersion(eq(5L), any(), any());
     assertThat(status.getDpaPublished()).isTrue();
     assertThat(status.getDpaSigned()).isFalse();
+  }
+
+  @Test
+  void getVersions_Should_assertTenantAccess_andMapVersions() {
+    // given
+    when(tenantDpaService.getVersions(5L))
+        .thenReturn(
+            List.of(
+                TenantDpaVersionEntity.builder()
+                    .activationDate(LocalDateTime.now())
+                    .content("{\"de\":\"x\"}")
+                    .build()));
+
+    // when
+    var result = tenantDpaFacade.getVersions(5L);
+
+    // then
+    verify(tenantFacadeAuthorisationService).assertUserIsAuthorizedToAccessTenant(5L);
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getContent()).isEqualTo("{\"de\":\"x\"}");
+    assertThat(result.get(0).getActivationDate()).isNotBlank();
   }
 }

--- a/src/test/java/com/vi/tenantservice/api/facade/TenantDpaFacadeTest.java
+++ b/src/test/java/com/vi/tenantservice/api/facade/TenantDpaFacadeTest.java
@@ -175,4 +175,35 @@ class TenantDpaFacadeTest {
     assertThat(result.get(0).getContent()).isEqualTo("{\"de\":\"x\"}");
     assertThat(result.get(0).getActivationDate()).isNotBlank();
   }
+
+  @Test
+  void publishDpa_Should_publishWithoutSanitizing_When_contentMapIsNull() {
+    when(tenantService.findTenantById(5L)).thenReturn(Optional.of(new TenantEntity()));
+
+    var status = tenantDpaFacade.publishDpa(5L, null);
+
+    verify(inputSanitizer, never()).sanitizeAllowingFormattingAndLinks(any());
+    verify(tenantDpaService).recordPublishedVersion(eq(5L), any(), any());
+    assertThat(status.getDpaPublished()).isTrue();
+  }
+
+  @Test
+  void publishDpa_Should_useLinkAllowingSanitiser_forEveryLanguage() {
+    when(tenantService.findTenantById(5L)).thenReturn(Optional.of(new TenantEntity()));
+    when(inputSanitizer.sanitizeAllowingFormattingAndLinks(any())).thenReturn("clean");
+
+    tenantDpaFacade.publishDpa(5L, Map.of("de", "<p>d</p>", "en", "<p>e</p>"));
+
+    verify(inputSanitizer).sanitizeAllowingFormattingAndLinks("<p>d</p>");
+    verify(inputSanitizer).sanitizeAllowingFormattingAndLinks("<p>e</p>");
+  }
+
+  @Test
+  void publishDpa_Should_throwNotFound_When_tenantMissing() {
+    when(tenantService.findTenantById(5L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> tenantDpaFacade.publishDpa(5L, Map.of("de", "x")))
+        .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
+    verify(tenantDpaService, never()).recordPublishedVersion(any(), any(), any());
+  }
 }

--- a/src/test/java/com/vi/tenantservice/api/facade/TenantDpaFacadeTest.java
+++ b/src/test/java/com/vi/tenantservice/api/facade/TenantDpaFacadeTest.java
@@ -1,0 +1,102 @@
+package com.vi.tenantservice.api.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.vi.tenantservice.api.model.DpaSignatureStatus;
+import com.vi.tenantservice.api.model.TenantDpaSignatureEntity;
+import com.vi.tenantservice.api.model.TenantEntity;
+import com.vi.tenantservice.api.service.TenantDpaService;
+import com.vi.tenantservice.api.service.TenantService;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+@ExtendWith(MockitoExtension.class)
+class TenantDpaFacadeTest {
+
+  @Mock private TenantDpaService tenantDpaService;
+  @Mock private TenantFacadeAuthorisationService tenantFacadeAuthorisationService;
+  @Mock private TenantService tenantService;
+  @InjectMocks private TenantDpaFacade tenantDpaFacade;
+
+  @Test
+  void getSignatures_Should_assertTenantAccess_andMapSignatures() {
+    // given
+    when(tenantDpaService.getSignatures(5L))
+        .thenReturn(
+            List.of(
+                TenantDpaSignatureEntity.builder()
+                    .tenantId(5L)
+                    .status(DpaSignatureStatus.SIGNED)
+                    .signerName("Erika")
+                    .signedAt(LocalDateTime.now())
+                    .build()));
+
+    // when
+    var result = tenantDpaFacade.getSignatures(5L);
+
+    // then — IDOR guard runs first
+    verify(tenantFacadeAuthorisationService).assertUserIsAuthorizedToAccessTenant(5L);
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getStatus()).isEqualTo("SIGNED");
+    assertThat(result.get(0).getSignerName()).isEqualTo("Erika");
+  }
+
+  @Test
+  void getSignatures_Should_throw_andNotQueryService_When_notAuthorizedForTenant() {
+    // given
+    doThrow(new AccessDeniedException("nope"))
+        .when(tenantFacadeAuthorisationService)
+        .assertUserIsAuthorizedToAccessTenant(5L);
+
+    // when / then
+    assertThatThrownBy(() -> tenantDpaFacade.getSignatures(5L))
+        .isInstanceOf(AccessDeniedException.class);
+    verifyNoInteractions(tenantDpaService);
+  }
+
+  @Test
+  void getGateStatus_Should_reportPublishedAndSigned() {
+    // given
+    var version = LocalDateTime.now();
+    var tenant = new TenantEntity();
+    tenant.setContentDataProcessingAgreementActivationDate(version);
+    when(tenantService.findTenantById(5L)).thenReturn(Optional.of(tenant));
+    when(tenantDpaService.isSignedForVersion(5L, version)).thenReturn(true);
+
+    // when
+    var status = tenantDpaFacade.getGateStatus(5L);
+
+    // then
+    verify(tenantFacadeAuthorisationService).assertUserIsAuthorizedToAccessTenant(5L);
+    assertThat(status.getDpaPublished()).isTrue();
+    assertThat(status.getDpaSigned()).isTrue();
+  }
+
+  @Test
+  void getGateStatus_Should_reportNotPublished_andSkipSignedCheck_When_noActivationDate() {
+    // given a tenant with no DPA activation date (not published)
+    when(tenantService.findTenantById(5L)).thenReturn(Optional.of(new TenantEntity()));
+
+    // when
+    var status = tenantDpaFacade.getGateStatus(5L);
+
+    // then
+    assertThat(status.getDpaPublished()).isFalse();
+    assertThat(status.getDpaSigned()).isFalse();
+    verify(tenantDpaService, never()).isSignedForVersion(any(), any());
+  }
+}

--- a/src/test/java/com/vi/tenantservice/api/facade/TenantDpaFacadeTest.java
+++ b/src/test/java/com/vi/tenantservice/api/facade/TenantDpaFacadeTest.java
@@ -3,6 +3,7 @@ package com.vi.tenantservice.api.facade;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -12,6 +13,7 @@ import static org.mockito.Mockito.when;
 import com.vi.tenantservice.api.model.DpaSignatureStatus;
 import com.vi.tenantservice.api.model.TenantDpaSignatureEntity;
 import com.vi.tenantservice.api.model.TenantEntity;
+import com.vi.tenantservice.api.service.DpaNotPublishedException;
 import com.vi.tenantservice.api.service.TenantDpaService;
 import com.vi.tenantservice.api.service.TenantService;
 import java.time.LocalDateTime;
@@ -98,5 +100,34 @@ class TenantDpaFacadeTest {
     assertThat(status.getDpaPublished()).isFalse();
     assertThat(status.getDpaSigned()).isFalse();
     verify(tenantDpaService, never()).isSignedForVersion(any(), any());
+  }
+
+  @Test
+  void createSignInvite_Should_returnTokenAndLink_When_dpaPublished() {
+    // given a tenant with a published DPA
+    var tenant = new TenantEntity();
+    tenant.setContentDataProcessingAgreementActivationDate(LocalDateTime.now());
+    when(tenantService.findTenantById(5L)).thenReturn(Optional.of(tenant));
+    when(tenantDpaService.createSignInvite(eq(5L), any(), any())).thenReturn("RAWTOKEN");
+
+    // when
+    var result = tenantDpaFacade.createSignInvite(5L);
+
+    // then
+    verify(tenantFacadeAuthorisationService).assertUserIsAuthorizedToAccessTenant(5L);
+    assertThat(result.getToken()).isEqualTo("RAWTOKEN");
+    assertThat(result.getSignLink()).endsWith("/dpa-sign/RAWTOKEN");
+    assertThat(result.getExpiresAt()).isNotBlank();
+  }
+
+  @Test
+  void createSignInvite_Should_throw_When_dpaNotPublished() {
+    // given a tenant with no DPA activation date
+    when(tenantService.findTenantById(5L)).thenReturn(Optional.of(new TenantEntity()));
+
+    // when / then
+    assertThatThrownBy(() -> tenantDpaFacade.createSignInvite(5L))
+        .isInstanceOf(DpaNotPublishedException.class);
+    verify(tenantDpaService, never()).createSignInvite(any(), any(), any());
   }
 }

--- a/src/test/java/com/vi/tenantservice/api/repository/TenantDpaSignatureRepositoryTest.java
+++ b/src/test/java/com/vi/tenantservice/api/repository/TenantDpaSignatureRepositoryTest.java
@@ -152,4 +152,33 @@ class TenantDpaSignatureRepositoryTest {
     assertThat(signatureRepository.findByTokenHashAndStatus("HASH", DpaSignatureStatus.PENDING))
         .isEmpty();
   }
+
+  @Test
+  void deleteByStatusAndCreateDateBefore_Should_removeOnlyDeniedBeforeCutoff() {
+    var now = LocalDateTime.now();
+    var cutoff = now.minusDays(365);
+    signatureRepository.save(denied(9L, now.minusDays(400))); // old denied -> purge
+    signatureRepository.save(denied(9L, now.minusDays(10))); // recent denied -> keep
+    signatureRepository.save(
+        TenantDpaSignatureEntity.builder()
+            .tenantId(9L)
+            .status(DpaSignatureStatus.SIGNED)
+            .createDate(now.minusDays(400))
+            .build()); // old but SIGNED -> keep
+    signatureRepository.flush();
+
+    long removed =
+        signatureRepository.deleteByStatusAndCreateDateBefore(DpaSignatureStatus.DENIED, cutoff);
+
+    assertThat(removed).isEqualTo(1);
+    assertThat(signatureRepository.findByTenantId(9L)).hasSize(2);
+  }
+
+  private TenantDpaSignatureEntity denied(Long tenantId, java.time.LocalDateTime createDate) {
+    return TenantDpaSignatureEntity.builder()
+        .tenantId(tenantId)
+        .status(DpaSignatureStatus.DENIED)
+        .createDate(createDate)
+        .build();
+  }
 }

--- a/src/test/java/com/vi/tenantservice/api/repository/TenantDpaSignatureRepositoryTest.java
+++ b/src/test/java/com/vi/tenantservice/api/repository/TenantDpaSignatureRepositoryTest.java
@@ -6,6 +6,7 @@ import com.vi.tenantservice.api.model.DpaSignatureStatus;
 import com.vi.tenantservice.api.model.TenantDpaSignatureEntity;
 import com.vi.tenantservice.api.model.TenantEntity;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -172,6 +173,23 @@ class TenantDpaSignatureRepositoryTest {
 
     assertThat(removed).isEqualTo(1);
     assertThat(signatureRepository.findByTenantId(9L)).hasSize(2);
+  }
+
+  @Test
+  void deleteByStatusAndCreateDateBefore_Should_keepRowExactlyAtCutoff() {
+    // strict "before" window: a DENIED row created exactly at the cutoff must be kept, not purged
+    var cutoff = LocalDateTime.now().minusDays(365).truncatedTo(ChronoUnit.SECONDS);
+    signatureRepository.save(denied(11L, cutoff.minusSeconds(1))); // just before -> purge
+    signatureRepository.save(denied(11L, cutoff)); // exactly at cutoff -> keep
+    signatureRepository.flush();
+
+    long removed =
+        signatureRepository.deleteByStatusAndCreateDateBefore(DpaSignatureStatus.DENIED, cutoff);
+
+    assertThat(removed).isEqualTo(1);
+    var survivors = signatureRepository.findByTenantId(11L);
+    assertThat(survivors).hasSize(1);
+    assertThat(survivors.get(0).getCreateDate()).isEqualTo(cutoff);
   }
 
   private TenantDpaSignatureEntity denied(Long tenantId, java.time.LocalDateTime createDate) {

--- a/src/test/java/com/vi/tenantservice/api/repository/TenantDpaVersionRepositoryTest.java
+++ b/src/test/java/com/vi/tenantservice/api/repository/TenantDpaVersionRepositoryTest.java
@@ -1,0 +1,78 @@
+package com.vi.tenantservice.api.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.vi.tenantservice.api.model.TenantDpaVersionEntity;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * Self-contained persistence test for the DPA version-history entity: proves the entity↔column
+ * mapping builds against a real (H2) schema and that the newest-first ordering query works. Mirrors
+ * {@link TenantDpaSignatureRepositoryTest}'s H2/create-drop override.
+ */
+@TestPropertySource(
+    properties = {
+      "spring.profiles.active=testing",
+      "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
+      "spring.jpa.hibernate.ddl-auto=create-drop"
+    })
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+class TenantDpaVersionRepositoryTest {
+
+  @Autowired private TenantDpaVersionRepository versionRepository;
+
+  @Test
+  void save_Should_persistSnapshot_andApplyCreateDateDefault() {
+    var activation = LocalDateTime.now();
+    var saved =
+        versionRepository.saveAndFlush(
+            TenantDpaVersionEntity.builder()
+                .tenantId(1L)
+                .content("{\"de\":\"v1\"}")
+                .activationDate(activation)
+                .build()); // createDate left null -> @PrePersist fills it
+
+    var reloaded = versionRepository.findById(saved.getId()).orElseThrow();
+    assertThat(reloaded.getTenantId()).isEqualTo(1L);
+    assertThat(reloaded.getContent()).isEqualTo("{\"de\":\"v1\"}");
+    assertThat(reloaded.getActivationDate()).isEqualTo(activation);
+    assertThat(reloaded.getCreateDate()).isNotNull();
+  }
+
+  @Test
+  void findByTenantIdOrderByActivationDateDesc_Should_returnNewestFirst_andScopeByTenant() {
+    var base = LocalDateTime.now();
+    versionRepository.save(version(1L, base.minusDays(2), "oldest"));
+    versionRepository.save(version(1L, base, "newest"));
+    versionRepository.save(version(1L, base.minusDays(1), "middle"));
+    versionRepository.save(version(2L, base, "other-tenant")); // must NOT leak
+    versionRepository.flush();
+
+    List<TenantDpaVersionEntity> found =
+        versionRepository.findByTenantIdOrderByActivationDateDesc(1L);
+
+    assertThat(found).hasSize(3);
+    assertThat(found)
+        .extracting(TenantDpaVersionEntity::getContent)
+        .containsExactly("newest", "middle", "oldest");
+  }
+
+  private TenantDpaVersionEntity version(Long tenantId, LocalDateTime activation, String content) {
+    return TenantDpaVersionEntity.builder()
+        .tenantId(tenantId)
+        .activationDate(activation)
+        .content(content)
+        .createDate(LocalDateTime.now())
+        .build();
+  }
+}

--- a/src/test/java/com/vi/tenantservice/api/service/TenantDpaRetentionServiceTest.java
+++ b/src/test/java/com/vi/tenantservice/api/service/TenantDpaRetentionServiceTest.java
@@ -1,0 +1,46 @@
+package com.vi.tenantservice.api.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.vi.tenantservice.api.model.DpaSignatureStatus;
+import com.vi.tenantservice.api.repository.TenantDpaSignatureRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class TenantDpaRetentionServiceTest {
+
+  @Mock private TenantDpaSignatureRepository signatureRepository;
+  @InjectMocks private TenantDpaRetentionService retentionService;
+
+  @Test
+  void purgeExpiredDeniedSignatures_Should_deleteDeniedOlderThanRetentionWindow() {
+    // given a 365-day window
+    ReflectionTestUtils.setField(retentionService, "deniedRetentionDays", 365L);
+    when(signatureRepository.deleteByStatusAndCreateDateBefore(
+            eq(DpaSignatureStatus.DENIED), any(LocalDateTime.class)))
+        .thenReturn(3L);
+
+    // when
+    long removed = retentionService.purgeExpiredDeniedSignatures();
+
+    // then only DENIED are targeted, with a cutoff ~ now - 365 days
+    assertThat(removed).isEqualTo(3);
+    var cutoff = ArgumentCaptor.forClass(LocalDateTime.class);
+    verify(signatureRepository)
+        .deleteByStatusAndCreateDateBefore(eq(DpaSignatureStatus.DENIED), cutoff.capture());
+    assertThat(cutoff.getValue())
+        .isBefore(LocalDateTime.now().minusDays(364))
+        .isAfter(LocalDateTime.now().minusDays(366));
+  }
+}

--- a/src/test/java/com/vi/tenantservice/api/service/TenantDpaServiceTest.java
+++ b/src/test/java/com/vi/tenantservice/api/service/TenantDpaServiceTest.java
@@ -10,7 +10,9 @@ import static org.mockito.Mockito.when;
 
 import com.vi.tenantservice.api.model.DpaSignatureStatus;
 import com.vi.tenantservice.api.model.TenantDpaSignatureEntity;
+import com.vi.tenantservice.api.model.TenantDpaVersionEntity;
 import com.vi.tenantservice.api.repository.TenantDpaSignatureRepository;
+import com.vi.tenantservice.api.repository.TenantDpaVersionRepository;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -26,6 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class TenantDpaServiceTest {
 
   @Mock private TenantDpaSignatureRepository signatureRepository;
+  @Mock private TenantDpaVersionRepository versionRepository;
   @InjectMocks private TenantDpaService tenantDpaService;
 
   @Test
@@ -85,6 +88,34 @@ class TenantDpaServiceTest {
 
     // when / then
     assertThat(tenantDpaService.getSignatures(5L)).hasSize(1);
+  }
+
+  @Test
+  void recordPublishedVersion_Should_saveSnapshot() {
+    // given
+    var activationDate = LocalDateTime.now();
+
+    // when
+    tenantDpaService.recordPublishedVersion(5L, "{\"de\":\"x\"}", activationDate);
+
+    // then
+    var captor = ArgumentCaptor.forClass(TenantDpaVersionEntity.class);
+    verify(versionRepository).save(captor.capture());
+    var saved = captor.getValue();
+    assertThat(saved.getTenantId()).isEqualTo(5L);
+    assertThat(saved.getContent()).isEqualTo("{\"de\":\"x\"}");
+    assertThat(saved.getActivationDate()).isEqualTo(activationDate);
+    assertThat(saved.getCreateDate()).isNotNull();
+  }
+
+  @Test
+  void getVersions_Should_returnFromRepoNewestFirst() {
+    // given
+    when(versionRepository.findByTenantIdOrderByActivationDateDesc(5L))
+        .thenReturn(List.of(TenantDpaVersionEntity.builder().tenantId(5L).build()));
+
+    // when / then
+    assertThat(tenantDpaService.getVersions(5L)).hasSize(1);
   }
 
   @Test


### PR DESCRIPTION
Second slice of the AVV / Legal flow (EPIC #46), continuing after the review-only #47 (DPA model + secure sign flow) which is already merged. Built locally and TDD-green; brings `feat/avv-legal-flow` up to date with `dev`.

## What's in this PR
- **Admin DPA endpoints**: `GET …/dpa/signatures` (audit list) + `GET …/dpa/gate` (published/signed), `POST …/dpa/invite` (secure single-use sign link), `PUT …/dpa` **publish** (multilingual JSON map + OWASP sanitize) — all IDOR-guarded via `TenantDpaFacade` → `assertUserIsAuthorizedToAccessTenant`.
- **DPA version history**: `tenant_dpa_version` table + `GET …/dpa/versions` (append-on-publish).
- **Retention**: DENIED signatures auto-purged after a configurable window (default 365d) via a daily `@Scheduled` job.
- **Review fixes** (3-agent adversarial): publish version key truncated to seconds to match `DATETIME(0)` + `@Transactional`; scheduler `@Transactional` (self-invocation); retention window floored at 1 day.

## Tests
All TDD-green locally (self-sufficient `@DataJpaTest` with H2 dialect override; service/controller/facade unit tests). Retention: service + `@DataJpaTest` incl. exactly-at-cutoff boundary.

Affected repos: ORISO-TenantService.

🤖 Generated with [Claude Code](https://claude.com/claude-code)