### PR TITLE
Extend DPA signature audit fields

### DIFF
--- a/api/tenantservice.yaml
+++ b/api/tenantservice.yaml
@@ -596,6 +596,11 @@ components:
       type: object
       required:
         - signerName
+        - signerPosition
+        - signerEmail
+        - signerOrganisation
+        - language
+        - accepted
       properties:
         signerName:
           type: string
@@ -605,9 +610,29 @@ components:
           type: string
           maxLength: 255
           example: "Geschäftsführerin"
+        signerEmail:
+          type: string
+          maxLength: 255
+          format: email
+          example: "erika.mustermann@example.org"
+        signerOrganisation:
+          type: string
+          maxLength: 255
+          example: "Caritas Beispiel e.V."
+        forwardedByUserId:
+          type: string
+          maxLength: 64
+          example: "tenant-admin-1"
+        source:
+          type: string
+          maxLength: 64
+          example: "PUBLIC_SIGN_LINK"
         signerIsMember:
           type: boolean
           example: false
+        accepted:
+          type: boolean
+          example: true
         language:
           type: string
           maxLength: 10
@@ -622,6 +647,16 @@ components:
           type: string
           example: "SIGNED"
         signerName:
+          type: string
+        signerPosition:
+          type: string
+        signerEmail:
+          type: string
+        signerOrganisation:
+          type: string
+        forwardedByUserId:
+          type: string
+        source:
           type: string
         signedAt:
           type: string

--- a/src/main/java/com/vi/tenantservice/api/controller/TenantController.java
+++ b/src/main/java/com/vi/tenantservice/api/controller/TenantController.java
@@ -60,11 +60,18 @@ public class TenantController implements TenantApi, TenantadminApi {
   @Override
   public ResponseEntity<DpaSignatureDTO> confirmDataProcessingAgreement(
       String token, DpaSignatureRequestDTO request) {
+    if (!Boolean.TRUE.equals(request.getAccepted())) {
+      return ResponseEntity.badRequest().build();
+    }
     var signature =
         tenantDpaService.confirmSignature(
             token,
             request.getSignerName(),
             request.getSignerPosition(),
+            request.getSignerEmail(),
+            request.getSignerOrganisation(),
+            request.getForwardedByUserId(),
+            request.getSource(),
             Boolean.TRUE.equals(request.getSignerIsMember()),
             request.getLanguage());
     var dto =
@@ -72,6 +79,11 @@ public class TenantController implements TenantApi, TenantadminApi {
             .tenantId(signature.getTenantId())
             .status(signature.getStatus() == null ? null : signature.getStatus().name())
             .signerName(signature.getSignerName())
+            .signerPosition(signature.getSignerPosition())
+            .signerEmail(signature.getSignerEmail())
+            .signerOrganisation(signature.getSignerOrganisation())
+            .forwardedByUserId(signature.getForwardedByUserId())
+            .source(signature.getSource())
             .signedAt(signature.getSignedAt() == null ? null : signature.getSignedAt().toString());
     return ResponseEntity.ok(dto);
   }

--- a/src/main/java/com/vi/tenantservice/api/facade/TenantDpaFacade.java
+++ b/src/main/java/com/vi/tenantservice/api/facade/TenantDpaFacade.java
@@ -146,6 +146,11 @@ public class TenantDpaFacade {
         .tenantId(entity.getTenantId())
         .status(entity.getStatus() == null ? null : entity.getStatus().name())
         .signerName(entity.getSignerName())
+        .signerPosition(entity.getSignerPosition())
+        .signerEmail(entity.getSignerEmail())
+        .signerOrganisation(entity.getSignerOrganisation())
+        .forwardedByUserId(entity.getForwardedByUserId())
+        .source(entity.getSource())
         .signedAt(entity.getSignedAt() == null ? null : entity.getSignedAt().toString());
   }
 }

--- a/src/main/java/com/vi/tenantservice/api/model/TenantDpaSignatureEntity.java
+++ b/src/main/java/com/vi/tenantservice/api/model/TenantDpaSignatureEntity.java
@@ -60,6 +60,18 @@ public class TenantDpaSignatureEntity {
   @Column(name = "signer_position")
   private String signerPosition;
 
+  @Column(name = "signer_email")
+  private String signerEmail;
+
+  @Column(name = "signer_organisation")
+  private String signerOrganisation;
+
+  @Column(name = "forwarded_by_user_id")
+  private String forwardedByUserId;
+
+  @Column(name = "source")
+  private String source;
+
   /**
    * Whether the signer is a platform member. {@code false} = an external person (e.g. a CEO) who
    * confirmed via a forwarded link without holding a platform account.

--- a/src/main/java/com/vi/tenantservice/api/repository/TenantDpaSignatureRepository.java
+++ b/src/main/java/com/vi/tenantservice/api/repository/TenantDpaSignatureRepository.java
@@ -34,6 +34,8 @@ public interface TenantDpaSignatureRepository
       "update TenantDpaSignatureEntity s set "
           + "s.status = com.vi.tenantservice.api.model.DpaSignatureStatus.SIGNED, "
           + "s.signerName = :signerName, s.signerPosition = :signerPosition, "
+          + "s.signerEmail = :signerEmail, s.signerOrganisation = :signerOrganisation, "
+          + "s.forwardedByUserId = :forwardedByUserId, s.source = :source, "
           + "s.signerIsMember = :signerIsMember, s.language = :language, "
           + "s.signedAt = :now, s.tokenHash = null "
           + "where s.tokenHash = :tokenHash "
@@ -42,6 +44,10 @@ public interface TenantDpaSignatureRepository
       @Param("tokenHash") String tokenHash,
       @Param("signerName") String signerName,
       @Param("signerPosition") String signerPosition,
+      @Param("signerEmail") String signerEmail,
+      @Param("signerOrganisation") String signerOrganisation,
+      @Param("forwardedByUserId") String forwardedByUserId,
+      @Param("source") String source,
       @Param("signerIsMember") Boolean signerIsMember,
       @Param("language") String language,
       @Param("now") LocalDateTime now);

--- a/src/main/java/com/vi/tenantservice/api/service/TenantDpaService.java
+++ b/src/main/java/com/vi/tenantservice/api/service/TenantDpaService.java
@@ -38,6 +38,31 @@ public class TenantDpaService {
       String signerPosition,
       boolean signerIsMember,
       String language) {
+    return recordSignature(
+        tenantId,
+        dpaVersion,
+        signerName,
+        signerPosition,
+        null,
+        null,
+        null,
+        null,
+        signerIsMember,
+        language);
+  }
+
+  /** Persists a SIGNED confirmation of the given DPA version for a tenant. */
+  public TenantDpaSignatureEntity recordSignature(
+      Long tenantId,
+      LocalDateTime dpaVersion,
+      String signerName,
+      String signerPosition,
+      String signerEmail,
+      String signerOrganisation,
+      String forwardedByUserId,
+      String source,
+      boolean signerIsMember,
+      String language) {
     var now = LocalDateTime.now();
     return signatureRepository.save(
         TenantDpaSignatureEntity.builder()
@@ -45,6 +70,10 @@ public class TenantDpaService {
             .dpaVersion(dpaVersion)
             .signerName(signerName)
             .signerPosition(signerPosition)
+            .signerEmail(signerEmail)
+            .signerOrganisation(signerOrganisation)
+            .forwardedByUserId(forwardedByUserId)
+            .source(normalizeSource(source))
             .signerIsMember(signerIsMember)
             .language(language)
             .status(DpaSignatureStatus.SIGNED)
@@ -113,6 +142,10 @@ public class TenantDpaService {
       String rawToken,
       String signerName,
       String signerPosition,
+      String signerEmail,
+      String signerOrganisation,
+      String forwardedByUserId,
+      String source,
       boolean signerIsMember,
       String language) {
     if (rawToken == null || rawToken.isBlank()) {
@@ -133,7 +166,16 @@ public class TenantDpaService {
     // produces exactly one winner (1 row) and the rest see 0.
     int consumed =
         signatureRepository.consumeSignToken(
-            tokenHash, signerName, signerPosition, signerIsMember, language, now);
+            tokenHash,
+            signerName,
+            signerPosition,
+            signerEmail,
+            signerOrganisation,
+            forwardedByUserId,
+            normalizeSource(source),
+            signerIsMember,
+            language,
+            now);
     if (consumed == 0) {
       throw new InvalidDpaSignTokenException("Sign token has already been used");
     }
@@ -141,11 +183,19 @@ public class TenantDpaService {
     // return.
     pending.setSignerName(signerName);
     pending.setSignerPosition(signerPosition);
+    pending.setSignerEmail(signerEmail);
+    pending.setSignerOrganisation(signerOrganisation);
+    pending.setForwardedByUserId(forwardedByUserId);
+    pending.setSource(normalizeSource(source));
     pending.setSignerIsMember(signerIsMember);
     pending.setLanguage(language);
     pending.setStatus(DpaSignatureStatus.SIGNED);
     pending.setSignedAt(now);
     pending.setTokenHash(null);
     return pending;
+  }
+
+  private static String normalizeSource(String source) {
+    return source == null || source.isBlank() ? "PUBLIC_SIGN_LINK" : source;
   }
 }

--- a/src/main/resources/db/changelog/changeset/0019_tenant_dpa_signature_audit_fields/0019-changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0019_tenant_dpa_signature_audit_fields/0019-changeSet.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+    <changeSet author="oriso" id="addTenantDpaSignatureAuditFields">
+        <sqlFile path="db/changelog/changeset/0019_tenant_dpa_signature_audit_fields/addTenantDpaSignatureAuditFields.sql" stripComments="true" />
+        <rollback>
+            <sqlFile path="db/changelog/changeset/0019_tenant_dpa_signature_audit_fields/addTenantDpaSignatureAuditFields-rollback.sql" stripComments="true" />
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0019_tenant_dpa_signature_audit_fields/addTenantDpaSignatureAuditFields-rollback.sql
+++ b/src/main/resources/db/changelog/changeset/0019_tenant_dpa_signature_audit_fields/addTenantDpaSignatureAuditFields-rollback.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `tenantservice`.`tenant_dpa_signature` DROP COLUMN IF EXISTS source;
+ALTER TABLE `tenantservice`.`tenant_dpa_signature` DROP COLUMN IF EXISTS forwarded_by_user_id;
+ALTER TABLE `tenantservice`.`tenant_dpa_signature` DROP COLUMN IF EXISTS signer_organisation;
+ALTER TABLE `tenantservice`.`tenant_dpa_signature` DROP COLUMN IF EXISTS signer_email;

--- a/src/main/resources/db/changelog/changeset/0019_tenant_dpa_signature_audit_fields/addTenantDpaSignatureAuditFields.sql
+++ b/src/main/resources/db/changelog/changeset/0019_tenant_dpa_signature_audit_fields/addTenantDpaSignatureAuditFields.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `tenantservice`.`tenant_dpa_signature` ADD COLUMN IF NOT EXISTS signer_email varchar(255) NULL;
+ALTER TABLE `tenantservice`.`tenant_dpa_signature` ADD COLUMN IF NOT EXISTS signer_organisation varchar(255) NULL;
+ALTER TABLE `tenantservice`.`tenant_dpa_signature` ADD COLUMN IF NOT EXISTS forwarded_by_user_id varchar(64) NULL;
+ALTER TABLE `tenantservice`.`tenant_dpa_signature` ADD COLUMN IF NOT EXISTS source varchar(64) NULL;

--- a/src/main/resources/db/changelog/tenantservice-dev-master.xml
+++ b/src/main/resources/db/changelog/tenantservice-dev-master.xml
@@ -25,4 +25,5 @@
   <include file="db/changelog/changeset/0016_tenant_dpa_signature/0016-changeSet.xml"/>
   <include file="db/changelog/changeset/0017_tenant_dpa_signature_token/0017-changeSet.xml"/>
   <include file="db/changelog/changeset/0018_tenant_dpa_version/0018-changeSet.xml"/>
+  <include file="db/changelog/changeset/0019_tenant_dpa_signature_audit_fields/0019-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenantservice-local-master.xml
+++ b/src/main/resources/db/changelog/tenantservice-local-master.xml
@@ -25,4 +25,5 @@
 	<include file="db/changelog/changeset/0016_tenant_dpa_signature/0016-changeSet.xml"/>
 	<include file="db/changelog/changeset/0017_tenant_dpa_signature_token/0017-changeSet.xml"/>
 	<include file="db/changelog/changeset/0018_tenant_dpa_version/0018-changeSet.xml"/>
+	<include file="db/changelog/changeset/0019_tenant_dpa_signature_audit_fields/0019-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenantservice-prod-master.xml
+++ b/src/main/resources/db/changelog/tenantservice-prod-master.xml
@@ -22,4 +22,5 @@
   <include file="db/changelog/changeset/0016_tenant_dpa_signature/0016-changeSet.xml"/>
   <include file="db/changelog/changeset/0017_tenant_dpa_signature_token/0017-changeSet.xml"/>
   <include file="db/changelog/changeset/0018_tenant_dpa_version/0018-changeSet.xml"/>
+  <include file="db/changelog/changeset/0019_tenant_dpa_signature_audit_fields/0019-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/test/java/com/vi/tenantservice/api/controller/TenantControllerDpaConfirmTest.java
+++ b/src/test/java/com/vi/tenantservice/api/controller/TenantControllerDpaConfirmTest.java
@@ -3,6 +3,7 @@ package com.vi.tenantservice.api.controller;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.vi.tenantservice.api.facade.TenantDpaFacade;
@@ -45,7 +46,12 @@ class TenantControllerDpaConfirmTest {
         new DpaSignatureRequestDTO()
             .signerName("Erika M")
             .signerPosition("Geschäftsführerin")
+            .signerEmail("erika@example.org")
+            .signerOrganisation("Caritas Beispiel")
+            .forwardedByUserId("tenant-admin-1")
+            .source("PUBLIC_SIGN_LINK")
             .signerIsMember(false)
+            .accepted(true)
             .language("de");
     var signedAt = LocalDateTime.now();
     var entity =
@@ -53,9 +59,20 @@ class TenantControllerDpaConfirmTest {
             .tenantId(7L)
             .status(DpaSignatureStatus.SIGNED)
             .signerName("Erika M")
+            .signerEmail("erika@example.org")
+            .signerOrganisation("Caritas Beispiel")
             .signedAt(signedAt)
             .build();
-    when(tenantDpaService.confirmSignature("tok", "Erika M", "Geschäftsführerin", false, "de"))
+    when(tenantDpaService.confirmSignature(
+            "tok",
+            "Erika M",
+            "Geschäftsführerin",
+            "erika@example.org",
+            "Caritas Beispiel",
+            "tenant-admin-1",
+            "PUBLIC_SIGN_LINK",
+            false,
+            "de"))
         .thenReturn(entity);
 
     // when
@@ -67,6 +84,27 @@ class TenantControllerDpaConfirmTest {
     assertThat(response.getBody().getTenantId()).isEqualTo(7L);
     assertThat(response.getBody().getStatus()).isEqualTo("SIGNED");
     assertThat(response.getBody().getSignerName()).isEqualTo("Erika M");
+    assertThat(response.getBody().getSignerEmail()).isEqualTo("erika@example.org");
+    assertThat(response.getBody().getSignerOrganisation()).isEqualTo("Caritas Beispiel");
+  }
+
+  @Test
+  void confirmDataProcessingAgreement_Should_rejectMissingAcceptConfirmation() {
+    // given
+    var request =
+        new DpaSignatureRequestDTO()
+            .signerName("Erika M")
+            .signerPosition("Geschäftsführerin")
+            .signerEmail("erika@example.org")
+            .signerOrganisation("Caritas Beispiel")
+            .language("de");
+
+    // when
+    var response = controller.confirmDataProcessingAgreement("tok", request);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    verifyNoInteractions(tenantDpaService);
   }
 
   @Test

--- a/src/test/java/com/vi/tenantservice/api/facade/TenantDpaFacadeTest.java
+++ b/src/test/java/com/vi/tenantservice/api/facade/TenantDpaFacadeTest.java
@@ -48,6 +48,9 @@ class TenantDpaFacadeTest {
                     .tenantId(5L)
                     .status(DpaSignatureStatus.SIGNED)
                     .signerName("Erika")
+                    .signerEmail("erika@example.org")
+                    .signerOrganisation("Caritas Beispiel")
+                    .source("PUBLIC_SIGN_LINK")
                     .signedAt(LocalDateTime.now())
                     .build()));
 
@@ -59,6 +62,9 @@ class TenantDpaFacadeTest {
     assertThat(result).hasSize(1);
     assertThat(result.get(0).getStatus()).isEqualTo("SIGNED");
     assertThat(result.get(0).getSignerName()).isEqualTo("Erika");
+    assertThat(result.get(0).getSignerEmail()).isEqualTo("erika@example.org");
+    assertThat(result.get(0).getSignerOrganisation()).isEqualTo("Caritas Beispiel");
+    assertThat(result.get(0).getSource()).isEqualTo("PUBLIC_SIGN_LINK");
   }
 
   @Test

--- a/src/test/java/com/vi/tenantservice/api/repository/TenantDpaSignatureRepositoryTest.java
+++ b/src/test/java/com/vi/tenantservice/api/repository/TenantDpaSignatureRepositoryTest.java
@@ -138,9 +138,31 @@ class TenantDpaSignatureRepositoryTest {
                 .build());
 
     // when the first consume wins
-    int first = signatureRepository.consumeSignToken("HASH", "Erika", "GF", false, "de", now);
+    int first =
+        signatureRepository.consumeSignToken(
+            "HASH",
+            "Erika",
+            "GF",
+            "e@example.org",
+            "Caritas",
+            "admin-1",
+            "PUBLIC_SIGN_LINK",
+            false,
+            "de",
+            now);
     // and a second consume of the same token affects nothing (single-use)
-    int second = signatureRepository.consumeSignToken("HASH", "Mallory", "X", true, "en", now);
+    int second =
+        signatureRepository.consumeSignToken(
+            "HASH",
+            "Mallory",
+            "X",
+            "m@example.org",
+            "Bad Org",
+            "admin-2",
+            "PUBLIC_SIGN_LINK",
+            true,
+            "en",
+            now);
     signatureRepository.flush();
 
     // then
@@ -149,6 +171,10 @@ class TenantDpaSignatureRepositoryTest {
     var reloaded = signatureRepository.findById(pending.getId()).orElseThrow();
     assertThat(reloaded.getStatus()).isEqualTo(DpaSignatureStatus.SIGNED);
     assertThat(reloaded.getSignerName()).isEqualTo("Erika"); // not overwritten by the 2nd attempt
+    assertThat(reloaded.getSignerEmail()).isEqualTo("e@example.org");
+    assertThat(reloaded.getSignerOrganisation()).isEqualTo("Caritas");
+    assertThat(reloaded.getForwardedByUserId()).isEqualTo("admin-1");
+    assertThat(reloaded.getSource()).isEqualTo("PUBLIC_SIGN_LINK");
     assertThat(reloaded.getTokenHash()).isNull();
     assertThat(signatureRepository.findByTokenHashAndStatus("HASH", DpaSignatureStatus.PENDING))
         .isEmpty();

--- a/src/test/java/com/vi/tenantservice/api/service/TenantDpaServiceTest.java
+++ b/src/test/java/com/vi/tenantservice/api/service/TenantDpaServiceTest.java
@@ -159,6 +159,10 @@ class TenantDpaServiceTest {
             eq(DpaSignToken.hash(rawToken)),
             eq("Erika M"),
             eq("Geschäftsführerin"),
+            eq("erika@example.org"),
+            eq("Caritas Beispiel"),
+            eq("tenant-admin-1"),
+            eq("PUBLIC_SIGN_LINK"),
             eq(false),
             eq("de"),
             any(LocalDateTime.class)))
@@ -166,13 +170,36 @@ class TenantDpaServiceTest {
 
     // when
     var result =
-        tenantDpaService.confirmSignature(rawToken, "Erika M", "Geschäftsführerin", false, "de");
+        tenantDpaService.confirmSignature(
+            rawToken,
+            "Erika M",
+            "Geschäftsführerin",
+            "erika@example.org",
+            "Caritas Beispiel",
+            "tenant-admin-1",
+            "PUBLIC_SIGN_LINK",
+            false,
+            "de");
 
     // then
     verify(signatureRepository)
-        .consumeSignToken(any(), any(), any(), any(), any(), any(LocalDateTime.class));
+        .consumeSignToken(
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(LocalDateTime.class));
     assertThat(result.getStatus()).isEqualTo(DpaSignatureStatus.SIGNED);
     assertThat(result.getSignerName()).isEqualTo("Erika M");
+    assertThat(result.getSignerEmail()).isEqualTo("erika@example.org");
+    assertThat(result.getSignerOrganisation()).isEqualTo("Caritas Beispiel");
+    assertThat(result.getForwardedByUserId()).isEqualTo("tenant-admin-1");
+    assertThat(result.getSource()).isEqualTo("PUBLIC_SIGN_LINK");
     assertThat(result.getSignedAt()).isNotNull();
     assertThat(result.getTokenHash()).isNull(); // consumed -> single use
   }
@@ -180,7 +207,10 @@ class TenantDpaServiceTest {
   @Test
   void confirmSignature_Should_throw_When_tokenNullOrBlank() {
     // when / then
-    assertThatThrownBy(() -> tenantDpaService.confirmSignature(" ", "n", "p", false, "de"))
+    assertThatThrownBy(
+            () ->
+                tenantDpaService.confirmSignature(
+                    " ", "n", "p", null, null, null, null, false, "de"))
         .isInstanceOf(InvalidDpaSignTokenException.class);
     verifyNoInteractions(signatureRepository);
   }
@@ -198,11 +228,15 @@ class TenantDpaServiceTest {
     when(signatureRepository.findByTokenHashAndStatus(
             DpaSignToken.hash(rawToken), DpaSignatureStatus.PENDING))
         .thenReturn(Optional.of(pending));
-    when(signatureRepository.consumeSignToken(any(), any(), any(), any(), any(), any()))
+    when(signatureRepository.consumeSignToken(
+            any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(0);
 
     // when / then
-    assertThatThrownBy(() -> tenantDpaService.confirmSignature(rawToken, "n", "p", false, "de"))
+    assertThatThrownBy(
+            () ->
+                tenantDpaService.confirmSignature(
+                    rawToken, "n", "p", null, null, null, null, false, "de"))
         .isInstanceOf(InvalidDpaSignTokenException.class);
   }
 
@@ -212,7 +246,10 @@ class TenantDpaServiceTest {
     when(signatureRepository.findByTokenHashAndStatus(any(), any())).thenReturn(Optional.empty());
 
     // when / then
-    assertThatThrownBy(() -> tenantDpaService.confirmSignature("bad", "n", "p", false, "de"))
+    assertThatThrownBy(
+            () ->
+                tenantDpaService.confirmSignature(
+                    "bad", "n", "p", null, null, null, null, false, "de"))
         .isInstanceOf(InvalidDpaSignTokenException.class);
   }
 
@@ -231,7 +268,10 @@ class TenantDpaServiceTest {
         .thenReturn(Optional.of(pending));
 
     // when / then
-    assertThatThrownBy(() -> tenantDpaService.confirmSignature(rawToken, "n", "p", false, "de"))
+    assertThatThrownBy(
+            () ->
+                tenantDpaService.confirmSignature(
+                    rawToken, "n", "p", null, null, null, null, false, "de"))
         .isInstanceOf(InvalidDpaSignTokenException.class);
   }
 


### PR DESCRIPTION
## Problem
The DPA sign flow needs to preserve signer e-mail, organisation, forward source and explicit acceptance so external signers can be audited cleanly.

## Solution
- Add DPA signature audit columns and rollback SQL.
- Extend OpenAPI request/response DTOs.
- Persist signerEmail, signerOrganisation, forwardedByUserId and source.
- Reject public DPA confirmation unless `accepted=true`.

## Validation
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./mvnw -B -Dtest=TenantDpaServiceTest,TenantControllerDpaConfirmTest,TenantDpaFacadeTest,TenantDpaSignatureRepositoryTest test`

## Coordination
Companion Frontend PR posts these fields through `/dpa-sign/:token`. Merge before deploying TenantService dev image to Pre-Dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)