### PR TITLE
Fix staging DPA signature migration

### DIFF
--- a/src/main/resources/db/changelog/tenantservice-staging-master.xml
+++ b/src/main/resources/db/changelog/tenantservice-staging-master.xml
@@ -22,4 +22,5 @@
   <include file="db/changelog/changeset/0016_tenant_dpa_signature/0016-changeSet.xml"/>
   <include file="db/changelog/changeset/0017_tenant_dpa_signature_token/0017-changeSet.xml"/>
   <include file="db/changelog/changeset/0018_tenant_dpa_version/0018-changeSet.xml"/>
+  <include file="db/changelog/changeset/0019_tenant_dpa_signature_audit_fields/0019-changeSet.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
## Summary

- Includes the DPA signature audit-field migration in `tenantservice-staging-master.xml`.
- Fixes Pre-Dev after ORISO-TenantService#52, where the updated service reads `forwarded_by_user_id`, `signer_email`, `signer_organisation` and `source` but the staging changelog had not created those columns.

## Validation

- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./mvnw -B -Dtest='TenantDpaServiceTest,TenantControllerDpaConfirmTest,TenantDpaFacadeTest,TenantDpaSignatureRepositoryTest' test`
- `git diff --check`

Tracked in OpenResilienceInitiative/ORISO-Frontend#362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
