### PR TITLE
feat: machine translation backend for legal texts (OpenRouter/Mistral, P-A3)

### DIFF
--- a/api/tenantservice.yaml
+++ b/api/tenantservice.yaml
@@ -154,6 +154,116 @@ paths:
           description: FORBIDDEN - only super admin can update platform controls
         500:
           description: INTERNAL SERVER ERROR - server encountered unexpected condition
+  /tenantadmin/translation/keys:
+    get:
+      tags:
+        - tenant-controller
+      summary: 'Gets the configured machine-translation provider API keys, masked [Authorization: Super admin]'
+      description: 'Returns the platform-global translation provider API keys. Keys are always
+        returned MASKED (first characters plus the last 4, e.g. "sk-…abcd") and can never be read
+        back in full. A provider without a configured key is returned as null.'
+      operationId: getTranslationApiKeys
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TranslationApiKeysDTO'
+        401:
+          description: UNAUTHORIZED - no/invalid Keycloak token
+        403:
+          description: FORBIDDEN - only super admin can access translation provider keys
+        500:
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
+  /tenantadmin/translation/keys/{provider}:
+    put:
+      tags:
+        - tenant-controller
+      summary: 'Sets the machine-translation API key for a provider [Authorization: Super admin]'
+      description: 'Stores the API key for the given provider ("openrouter" or "mistral") in the
+        platform-global admin controls. Returns all keys masked.'
+      operationId: setTranslationApiKey
+      parameters:
+        - name: provider
+          in: path
+          description: Translation provider id, one of "openrouter" or "mistral"
+            (validated server-side, unknown providers are rejected with 400)
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TranslationApiKeyUpdateDTO'
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TranslationApiKeysDTO'
+        400:
+          description: BAD REQUEST - unknown provider or invalid/empty key
+        401:
+          description: UNAUTHORIZED - no/invalid Keycloak token
+        403:
+          description: FORBIDDEN - only super admin can update translation provider keys
+        500:
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
+  /tenantadmin/translate:
+    post:
+      tags:
+        - tenant-controller
+      summary: 'Machine-translates HTML texts into one or more target languages [Authorization: Authority.UPDATE_TENANT]'
+      description: 'Translates the given HTML texts (fieldKey -> HTML) from sourceLang into every
+        requested target language using an LLM provider (OpenRouter or Mistral) with the
+        platform-global API keys. HTML tags, attributes and structure are preserved; only
+        human-readable text is translated. If no provider is requested explicitly, openrouter is
+        used when its key is configured, otherwise mistral. Typed error codes:
+        TRANSLATION_NOT_CONFIGURED (409, no API key configured), TRANSLATION_KEY_INVALID (502,
+        provider rejected the key), TRANSLATION_NO_CREDIT (502, provider credit exhausted),
+        TRANSLATION_RATE_LIMITED (502, provider rate limit hit),
+        TRANSLATION_PROVIDER_UNAVAILABLE (502, provider timeout or 5xx). The response is meant to
+        be published together with the machine-translation metadata convention: for every machine
+        translated language the client stores a parallel "<lang>__meta" key with the strict JSON
+        value {"mt":true,"src":"<sourceLang>","at":"<ISO-timestamp>"} next to the translated HTML
+        in the same language->HTML map.'
+      operationId: translate
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TranslationRequestDTO'
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TranslationResponseDTO'
+        400:
+          description: BAD REQUEST - invalid/incomplete request or unknown provider
+        401:
+          description: UNAUTHORIZED - no/invalid Keycloak token
+        409:
+          description: CONFLICT - no translation provider API key configured (TRANSLATION_NOT_CONFIGURED)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TranslationErrorDTO'
+        502:
+          description: BAD GATEWAY - translation provider error (TRANSLATION_KEY_INVALID,
+            TRANSLATION_NO_CREDIT, TRANSLATION_RATE_LIMITED, TRANSLATION_PROVIDER_UNAVAILABLE)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TranslationErrorDTO'
+        500:
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
   /tenantadmin/{id}:
     put:
       tags:
@@ -520,7 +630,15 @@ paths:
             type: long
       requestBody:
         required: true
-        description: 'Per-language DPA HTML content (language code -> HTML)'
+        description: 'Per-language DPA HTML content (language code -> HTML). Supports the
+          machine-translation metadata convention: next to a translated language (e.g. "en") the
+          map may carry a parallel "en__meta" key whose value is the strict JSON string
+          {"mt":true,"src":"de","at":"<ISO-timestamp>"} marking the language as machine
+          translated. Meta values are validated as strict JSON with only these fields and stored
+          unsanitized; all other values are HTML-sanitized. When the HTML of a language is changed
+          manually (i.e. the content changed but the resent meta is the previously stored one),
+          the meta key for that language is removed - a manual edit clears the
+          machine-translated tag.'
         content:
           application/json:
             schema:
@@ -569,6 +687,88 @@ paths:
           description: INTERNAL SERVER ERROR - server encountered unexpected condition
 components:
   schemas:
+    TranslationApiKeysDTO:
+      type: object
+      description: 'Masked machine-translation provider API keys. A key is shown as its first
+        characters plus the last 4 (e.g. "sk-…abcd"); null means no key is configured for that
+        provider.'
+      properties:
+        openrouter:
+          type: string
+          example: "sk-…abcd"
+        mistral:
+          type: string
+          example: "Fgh…9xyz"
+    TranslationApiKeyUpdateDTO:
+      type: object
+      required:
+        - apiKey
+      properties:
+        apiKey:
+          type: string
+          minLength: 1
+          maxLength: 500
+          example: "sk-or-v1-0123456789abcdef"
+    TranslationRequestDTO:
+      type: object
+      required:
+        - sourceLang
+        - targetLangs
+        - texts
+      properties:
+        sourceLang:
+          type: string
+          maxLength: 10
+          example: "de"
+        targetLangs:
+          type: array
+          items:
+            type: string
+            maxLength: 10
+          minItems: 1
+          example: [ "en", "fr" ]
+        provider:
+          type: string
+          description: 'Optional explicit provider (openrouter or mistral). If omitted, openrouter
+            is used when its key is configured, otherwise mistral.'
+          example: "openrouter"
+        texts:
+          type: object
+          description: 'HTML texts to translate, keyed by a caller-defined field key
+            (e.g. "privacy", "impressum").'
+          additionalProperties:
+            type: string
+    TranslationResponseDTO:
+      type: object
+      description: 'Translations keyed by target language, each holding the translated HTML per
+        field key. HTML tags, attributes and structure are preserved by the provider prompt.'
+      properties:
+        translations:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: string
+        provider:
+          type: string
+          example: "openrouter"
+        model:
+          type: string
+          example: "openai/gpt-4o-mini"
+    TranslationErrorDTO:
+      type: object
+      description: 'Typed machine-translation error. errorCode is one of
+        TRANSLATION_NOT_CONFIGURED, TRANSLATION_KEY_INVALID, TRANSLATION_NO_CREDIT,
+        TRANSLATION_RATE_LIMITED, TRANSLATION_PROVIDER_UNAVAILABLE.'
+      properties:
+        errorCode:
+          type: string
+          example: "TRANSLATION_KEY_INVALID"
+        provider:
+          type: string
+          example: "openrouter"
+        message:
+          type: string
     DpaVersionDTO:
       type: object
       properties:

--- a/documentation/translation-meta.md
+++ b/documentation/translation-meta.md
@@ -1,0 +1,45 @@
+# Machine-translation metadata convention (`__meta` keys)
+
+Legal content (e.g. the tenant DPA, `tenant.content_dpa`) is stored as a JSON map
+`language -> HTML` in an existing LONGTEXT column. To mark a language as *machine translated*
+we store a parallel metadata key **inside the same map** — no schema change needed:
+
+```json
+{
+  "de": "<p>Original German text…</p>",
+  "en": "<p>Machine translated English text…</p>",
+  "en__meta": "{\"mt\":true,\"src\":\"de\",\"at\":\"2026-07-03T10:15:30Z\"}"
+}
+```
+
+## Rules
+
+- The meta key for language `<lang>` is `<lang>__meta` (see `TranslationMetaUtil`).
+- The meta value is a **strict JSON object** with only these fields:
+  - `mt` (boolean, required) — `true` = the language content is machine translated
+  - `src` (string) — the source language the translation was made from
+  - `at` (string) — ISO timestamp of the translation
+- Anything else (unknown fields, wrong types, malformed JSON) is rejected with HTTP 400
+  on publish.
+- Meta values are **not HTML-sanitized** (they are not HTML); all other map values go through
+  the OWASP sanitizer as before.
+- **A manual edit clears the machine-translated tag:** when a publish changes the HTML of a
+  language but merely resends the previously stored meta unchanged, that meta is removed.
+  A changed/new meta together with new content (a fresh machine translation) is stored.
+  A meta without content for its language is dropped.
+- Consumers that only want the content can use `TranslationMetaUtil.stripMetaKeys(map)`.
+
+## Where it applies
+
+- `PUT /tenantadmin/{id}/dpa` (DPA publish) accepts and stores meta keys per the rules above.
+- `POST /tenantadmin/translate` produces the translations; the Admin UI adds the
+  `<lang>__meta` entries when publishing machine-translated languages.
+
+## Related endpoints
+
+- `GET /tenantadmin/translation/keys` — masked provider API keys (super admin)
+- `PUT /tenantadmin/translation/keys/{provider}` — set key for `openrouter` / `mistral`
+  (super admin)
+- `POST /tenantadmin/translate` — translate HTML texts, typed error codes
+  (`TRANSLATION_NOT_CONFIGURED` 409; `TRANSLATION_KEY_INVALID`, `TRANSLATION_NO_CREDIT`,
+  `TRANSLATION_RATE_LIMITED`, `TRANSLATION_PROVIDER_UNAVAILABLE` 502)

--- a/src/main/java/com/vi/tenantservice/api/controller/TenantController.java
+++ b/src/main/java/com/vi/tenantservice/api/controller/TenantController.java
@@ -2,6 +2,7 @@ package com.vi.tenantservice.api.controller;
 
 import com.vi.tenantservice.api.facade.TenantDpaFacade;
 import com.vi.tenantservice.api.facade.TenantServiceFacade;
+import com.vi.tenantservice.api.facade.TranslationFacade;
 import com.vi.tenantservice.api.model.AdminTenantDTO;
 import com.vi.tenantservice.api.model.BasicTenantLicensingDTO;
 import com.vi.tenantservice.api.model.DpaGateStatusDTO;
@@ -14,9 +15,16 @@ import com.vi.tenantservice.api.model.RestrictedTenantDTO;
 import com.vi.tenantservice.api.model.TenantAdminControls;
 import com.vi.tenantservice.api.model.TenantDTO;
 import com.vi.tenantservice.api.model.TenantsSearchResultDTO;
+import com.vi.tenantservice.api.model.TranslationApiKeyUpdateDTO;
+import com.vi.tenantservice.api.model.TranslationApiKeysDTO;
+import com.vi.tenantservice.api.model.TranslationErrorDTO;
+import com.vi.tenantservice.api.model.TranslationRequestDTO;
+import com.vi.tenantservice.api.model.TranslationResponseDTO;
 import com.vi.tenantservice.api.service.DpaNotPublishedException;
 import com.vi.tenantservice.api.service.InvalidDpaSignTokenException;
 import com.vi.tenantservice.api.service.TenantDpaService;
+import com.vi.tenantservice.api.service.translation.TranslationErrorCode;
+import com.vi.tenantservice.api.service.translation.TranslationException;
 import com.vi.tenantservice.config.security.AuthorisationService;
 import com.vi.tenantservice.generated.api.controller.TenantApi;
 import com.vi.tenantservice.generated.api.controller.TenantadminApi;
@@ -53,6 +61,7 @@ public class TenantController implements TenantApi, TenantadminApi {
   private final @NonNull TenantDtoMapper tenantDtoMapper;
   private final @NonNull TenantDpaService tenantDpaService;
   private final @NonNull TenantDpaFacade tenantDpaFacade;
+  private final @NonNull TranslationFacade translationFacade;
 
   /**
    * Public DPA confirmation via a single-use sign token. No authentication: the token is the
@@ -160,9 +169,49 @@ public class TenantController implements TenantApi, TenantadminApi {
   @Override
   @PreAuthorize("hasAuthority('AUTHORIZATION_GET_ALL_TENANTS')")
   public ResponseEntity<TenantAdminControls> updateTenantAdminControls(
-      @jakarta.validation.Valid TenantAdminControls tenantAdminControls) {
+      TenantAdminControls tenantAdminControls) {
     return new ResponseEntity<>(
         tenantServiceFacade.updateTenantAdminControls(tenantAdminControls), HttpStatus.OK);
+  }
+
+  @Override
+  @PreAuthorize("hasAuthority('AUTHORIZATION_GET_ALL_TENANTS')")
+  public ResponseEntity<TranslationApiKeysDTO> getTranslationApiKeys() {
+    return new ResponseEntity<>(translationFacade.getMaskedApiKeys(), HttpStatus.OK);
+  }
+
+  @Override
+  @PreAuthorize("hasAuthority('AUTHORIZATION_GET_ALL_TENANTS')")
+  public ResponseEntity<TranslationApiKeysDTO> setTranslationApiKey(
+      String provider, TranslationApiKeyUpdateDTO translationApiKeyUpdateDTO) {
+    log.info(
+        "Updating translation API key for provider {} by user {}",
+        provider,
+        authorisationService.getUsername());
+    return new ResponseEntity<>(
+        translationFacade.setApiKey(provider, translationApiKeyUpdateDTO), HttpStatus.OK);
+  }
+
+  @Override
+  @PreAuthorize("hasAuthority('AUTHORIZATION_UPDATE_TENANT')")
+  public ResponseEntity<TranslationResponseDTO> translate(
+      TranslationRequestDTO translationRequestDTO) {
+    return new ResponseEntity<>(translationFacade.translate(translationRequestDTO), HttpStatus.OK);
+  }
+
+  @ExceptionHandler(TranslationException.class)
+  ResponseEntity<TranslationErrorDTO> handleTranslationException(TranslationException e) {
+    log.warn("Machine translation failed: {} ({})", e.getErrorCode(), e.getMessage());
+    var status =
+        e.getErrorCode() == TranslationErrorCode.TRANSLATION_NOT_CONFIGURED
+            ? HttpStatus.CONFLICT
+            : HttpStatus.BAD_GATEWAY;
+    var body =
+        new TranslationErrorDTO()
+            .errorCode(e.getErrorCode().name())
+            .provider(e.getProvider())
+            .message(e.getMessage());
+    return new ResponseEntity<>(body, status);
   }
 
   @Override
@@ -177,7 +226,7 @@ public class TenantController implements TenantApi, TenantadminApi {
   @Override
   @PreAuthorize("hasAuthority('AUTHORIZATION_CREATE_TENANT')")
   public ResponseEntity<MultilingualTenantDTO> createTenant(
-      @jakarta.validation.Valid MultilingualTenantDTO tenantMultilingualDTO) {
+      MultilingualTenantDTO tenantMultilingualDTO) {
     log.info("Creating tenant by user {} ", authorisationService.getUsername());
     var tenant = tenantServiceFacade.createTenant(tenantMultilingualDTO);
     return new ResponseEntity<>(tenant, HttpStatus.OK);
@@ -186,7 +235,7 @@ public class TenantController implements TenantApi, TenantadminApi {
   @Override
   @PreAuthorize("hasAuthority('AUTHORIZATION_UPDATE_TENANT')")
   public ResponseEntity<MultilingualTenantDTO> updateTenant(
-      Long id, @jakarta.validation.Valid MultilingualTenantDTO tenantDTO) {
+      Long id, MultilingualTenantDTO tenantDTO) {
     log.info("Updating tenant with id {} by user {} ", id, authorisationService.getUsername());
     var updatedTenantDTO = tenantServiceFacade.updateTenant(id, tenantDTO);
     return new ResponseEntity<>(updatedTenantDTO, HttpStatus.OK);

--- a/src/main/java/com/vi/tenantservice/api/facade/TenantDpaFacade.java
+++ b/src/main/java/com/vi/tenantservice/api/facade/TenantDpaFacade.java
@@ -11,6 +11,7 @@ import com.vi.tenantservice.api.service.DpaNotPublishedException;
 import com.vi.tenantservice.api.service.TenantDpaService;
 import com.vi.tenantservice.api.service.TenantService;
 import com.vi.tenantservice.api.util.JsonConverter;
+import com.vi.tenantservice.api.util.TranslationMetaUtil;
 import com.vi.tenantservice.api.validation.InputSanitizer;
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -18,6 +19,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -99,6 +101,13 @@ public class TenantDpaFacade {
    * stores it as the multilingual JSON content, and stamps a fresh activation date (= new contract
    * version). Returns the resulting gate status (published; signed is false until the new version
    * is confirmed).
+   *
+   * <p>Machine-translation metadata convention (see documentation/translation-meta.md): the map may
+   * carry parallel {@code <lang>__meta} keys marking a language as machine translated. Meta values
+   * are NOT html-sanitized but validated as strict JSON with only the known fields ({@code mt},
+   * {@code src}, {@code at}) and stored alongside the content. When the HTML of a language is
+   * changed while its previously stored {@code mt:true} meta is merely resent unchanged, that meta
+   * is removed - a manual edit clears the machine-translated tag.
    */
   @Transactional
   public DpaGateStatusDTO publishDpa(Long tenantId, Map<String, String> contentByLanguage) {
@@ -108,12 +117,29 @@ public class TenantDpaFacade {
             .findTenantById(tenantId)
             .orElseThrow(
                 () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Tenant not found"));
+    var previous = JsonConverter.convertMapFromJson(tenant.getContentDataProcessingAgreement());
     var sanitized = new LinkedHashMap<String, String>();
+    var metaByLanguage = new LinkedHashMap<String, String>();
     if (contentByLanguage != null) {
       contentByLanguage.forEach(
-          (lang, html) ->
-              sanitized.put(lang, inputSanitizer.sanitizeAllowingFormattingAndLinks(html)));
+          (key, value) -> {
+            if (TranslationMetaUtil.isMetaKey(key)) {
+              if (!TranslationMetaUtil.isValidMeta(value)) {
+                throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST, "Invalid translation metadata for key: " + key);
+              }
+              metaByLanguage.put(TranslationMetaUtil.languageOf(key), value);
+            } else {
+              sanitized.put(key, inputSanitizer.sanitizeAllowingFormattingAndLinks(value));
+            }
+          });
     }
+    metaByLanguage.forEach(
+        (lang, meta) -> {
+          if (shouldKeepMeta(lang, meta, sanitized, previous)) {
+            sanitized.put(TranslationMetaUtil.metaKeyFor(lang), meta);
+          }
+        });
     // Truncate to seconds so the in-memory version key matches the MariaDB DATETIME(0) column
     // after a round-trip — otherwise the signature gate (equals on dpa_version) could never match.
     var version = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
@@ -124,6 +150,28 @@ public class TenantDpaFacade {
     tenantDpaService.recordPublishedVersion(tenantId, json, version);
     boolean signed = tenantDpaService.isSignedForVersion(tenantId, version);
     return new DpaGateStatusDTO().dpaPublished(true).dpaSigned(signed);
+  }
+
+  /**
+   * Decides whether a submitted {@code <lang>__meta} entry is stored. A meta without content for
+   * its language is dropped (orphan). If the language's HTML is unchanged, the meta is kept
+   * (republish). If the HTML changed but the submitted meta equals the previously stored one, the
+   * meta is a stale round-trip of an {@code mt:true} tag over a manual edit - it is removed
+   * (Frank's rule: a manual edit clears the machine-translated tag). A changed/new meta together
+   * with changed content is a fresh machine translation and is stored.
+   */
+  private boolean shouldKeepMeta(
+      String lang, String meta, Map<String, String> sanitized, Map<String, String> previous) {
+    if (!sanitized.containsKey(lang)) {
+      return false;
+    }
+    var newHtml = sanitized.get(lang);
+    var previousHtml = previous.get(lang);
+    if (Objects.equals(newHtml, previousHtml)) {
+      return true;
+    }
+    var previousMeta = previous.get(TranslationMetaUtil.metaKeyFor(lang));
+    return !Objects.equals(meta, previousMeta);
   }
 
   /** The tenant's published DPA versions (newest first) for the read-only "look back" viewer. */

--- a/src/main/java/com/vi/tenantservice/api/facade/TranslationFacade.java
+++ b/src/main/java/com/vi/tenantservice/api/facade/TranslationFacade.java
@@ -14,10 +14,10 @@ import com.vi.tenantservice.api.service.translation.TranslationProviderClient;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
@@ -31,12 +31,26 @@ import org.springframework.web.server.ResponseStatusException;
  * Translation itself is available to tenant admins with the update authority.
  */
 @Service
-@RequiredArgsConstructor
 public class TranslationFacade {
 
   private final @NonNull TenantAdminControlsService tenantAdminControlsService;
   private final @NonNull TenantFacadeAuthorisationService tenantFacadeAuthorisationService;
-  private final @NonNull List<TranslationProviderClient> translationProviderClients;
+  private final Map<String, TranslationProviderClient> clientsById;
+
+  public TranslationFacade(
+      @NonNull TenantAdminControlsService tenantAdminControlsService,
+      @NonNull TenantFacadeAuthorisationService tenantFacadeAuthorisationService,
+      @NonNull List<TranslationProviderClient> translationProviderClients) {
+    this.tenantAdminControlsService = tenantAdminControlsService;
+    this.tenantFacadeAuthorisationService = tenantFacadeAuthorisationService;
+    this.clientsById =
+        translationProviderClients.stream()
+            .collect(
+                Collectors.toMap(TranslationProviderClient::getProviderId, Function.identity()));
+  }
+
+  /** A provider client together with the API key it was validated against (single read). */
+  private record ResolvedProvider(TranslationProviderClient client, String apiKey) {}
 
   /** Masked provider API keys (super admin only). */
   public TranslationApiKeysDTO getMaskedApiKeys() {
@@ -65,8 +79,9 @@ public class TranslationFacade {
    * @throws TranslationException typed provider errors, see {@link TranslationErrorCode}
    */
   public TranslationResponseDTO translate(TranslationRequestDTO request) {
-    var client = resolveProvider(request.getProvider());
-    var apiKey = tenantAdminControlsService.getTranslationApiKeys().get(client.getProviderId());
+    var resolved = resolveProvider(request.getProvider());
+    var client = resolved.client();
+    var apiKey = resolved.apiKey();
 
     var translations = new LinkedHashMap<String, Map<String, String>>();
     for (String targetLang : request.getTargetLangs()) {
@@ -86,7 +101,7 @@ public class TranslationFacade {
         .model(client.getModel());
   }
 
-  private TranslationProviderClient resolveProvider(String requestedProvider) {
+  private ResolvedProvider resolveProvider(String requestedProvider) {
     var apiKeys = tenantAdminControlsService.getTranslationApiKeys();
     if (StringUtils.isNotBlank(requestedProvider)) {
       var client =
@@ -96,18 +111,21 @@ public class TranslationFacade {
                       new ResponseStatusException(
                           HttpStatus.BAD_REQUEST,
                           "Unknown translation provider: " + requestedProvider));
-      if (StringUtils.isBlank(apiKeys.get(client.getProviderId()))) {
+      var apiKey = apiKeys.get(client.getProviderId());
+      if (StringUtils.isBlank(apiKey)) {
         throw new TranslationException(
             TranslationErrorCode.TRANSLATION_NOT_CONFIGURED,
             client.getProviderId(),
             "No API key configured for provider " + client.getProviderId());
       }
-      return client;
+      return new ResolvedProvider(client, apiKey);
     }
     // default order: openrouter if its key is set, else mistral
     for (String providerId : List.of(OpenRouterClient.PROVIDER_ID, MistralClient.PROVIDER_ID)) {
-      if (StringUtils.isNotBlank(apiKeys.get(providerId)) && clientFor(providerId).isPresent()) {
-        return clientFor(providerId).get();
+      var client = clientsById.get(providerId);
+      var apiKey = apiKeys.get(providerId);
+      if (client != null && StringUtils.isNotBlank(apiKey)) {
+        return new ResolvedProvider(client, apiKey);
       }
     }
     throw new TranslationException(
@@ -116,15 +134,8 @@ public class TranslationFacade {
         "No translation provider API key configured");
   }
 
-  private java.util.Optional<TranslationProviderClient> clientFor(String providerId) {
-    return clientsById().containsKey(providerId)
-        ? java.util.Optional.of(clientsById().get(providerId))
-        : java.util.Optional.empty();
-  }
-
-  private Map<String, TranslationProviderClient> clientsById() {
-    return translationProviderClients.stream()
-        .collect(Collectors.toMap(TranslationProviderClient::getProviderId, Function.identity()));
+  private Optional<TranslationProviderClient> clientFor(String providerId) {
+    return Optional.ofNullable(clientsById.get(providerId));
   }
 
   private TranslationApiKeysDTO maskedKeys() {

--- a/src/main/java/com/vi/tenantservice/api/facade/TranslationFacade.java
+++ b/src/main/java/com/vi/tenantservice/api/facade/TranslationFacade.java
@@ -1,0 +1,142 @@
+package com.vi.tenantservice.api.facade;
+
+import com.vi.tenantservice.api.model.TranslationApiKeyUpdateDTO;
+import com.vi.tenantservice.api.model.TranslationApiKeysDTO;
+import com.vi.tenantservice.api.model.TranslationRequestDTO;
+import com.vi.tenantservice.api.model.TranslationResponseDTO;
+import com.vi.tenantservice.api.service.TenantAdminControlsService;
+import com.vi.tenantservice.api.service.translation.ApiKeyMasker;
+import com.vi.tenantservice.api.service.translation.MistralClient;
+import com.vi.tenantservice.api.service.translation.OpenRouterClient;
+import com.vi.tenantservice.api.service.translation.TranslationErrorCode;
+import com.vi.tenantservice.api.service.translation.TranslationException;
+import com.vi.tenantservice.api.service.translation.TranslationProviderClient;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Machine translation for admin-managed legal texts. Provider API keys live in the platform-global
+ * admin controls (see {@link TenantAdminControlsService}); managing them mirrors the other
+ * super-admin settings guard ({@code isSuperAdmin}), and keys are only ever returned masked.
+ * Translation itself is available to tenant admins with the update authority.
+ */
+@Service
+@RequiredArgsConstructor
+public class TranslationFacade {
+
+  private final @NonNull TenantAdminControlsService tenantAdminControlsService;
+  private final @NonNull TenantFacadeAuthorisationService tenantFacadeAuthorisationService;
+  private final @NonNull List<TranslationProviderClient> translationProviderClients;
+
+  /** Masked provider API keys (super admin only). */
+  public TranslationApiKeysDTO getMaskedApiKeys() {
+    assertSuperAdmin();
+    return maskedKeys();
+  }
+
+  /** Sets a provider API key (super admin only) and returns all keys masked. */
+  public TranslationApiKeysDTO setApiKey(String provider, TranslationApiKeyUpdateDTO update) {
+    assertSuperAdmin();
+    if (clientFor(provider).isEmpty()) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Unknown translation provider: " + provider);
+    }
+    if (update == null || StringUtils.isBlank(update.getApiKey())) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "API key must not be empty");
+    }
+    tenantAdminControlsService.setTranslationApiKey(provider, update.getApiKey().trim());
+    return maskedKeys();
+  }
+
+  /**
+   * Translates the given HTML texts into every requested target language. Provider is picked
+   * explicitly or by default order: openrouter if its key is configured, else mistral.
+   *
+   * @throws TranslationException typed provider errors, see {@link TranslationErrorCode}
+   */
+  public TranslationResponseDTO translate(TranslationRequestDTO request) {
+    var client = resolveProvider(request.getProvider());
+    var apiKey = tenantAdminControlsService.getTranslationApiKeys().get(client.getProviderId());
+
+    var translations = new LinkedHashMap<String, Map<String, String>>();
+    for (String targetLang : request.getTargetLangs()) {
+      var translatedFields = new LinkedHashMap<String, String>();
+      request
+          .getTexts()
+          .forEach(
+              (fieldKey, html) ->
+                  translatedFields.put(
+                      fieldKey,
+                      client.translateHtml(apiKey, request.getSourceLang(), targetLang, html)));
+      translations.put(targetLang, translatedFields);
+    }
+    return new TranslationResponseDTO()
+        .translations(translations)
+        .provider(client.getProviderId())
+        .model(client.getModel());
+  }
+
+  private TranslationProviderClient resolveProvider(String requestedProvider) {
+    var apiKeys = tenantAdminControlsService.getTranslationApiKeys();
+    if (StringUtils.isNotBlank(requestedProvider)) {
+      var client =
+          clientFor(requestedProvider)
+              .orElseThrow(
+                  () ->
+                      new ResponseStatusException(
+                          HttpStatus.BAD_REQUEST,
+                          "Unknown translation provider: " + requestedProvider));
+      if (StringUtils.isBlank(apiKeys.get(client.getProviderId()))) {
+        throw new TranslationException(
+            TranslationErrorCode.TRANSLATION_NOT_CONFIGURED,
+            client.getProviderId(),
+            "No API key configured for provider " + client.getProviderId());
+      }
+      return client;
+    }
+    // default order: openrouter if its key is set, else mistral
+    for (String providerId : List.of(OpenRouterClient.PROVIDER_ID, MistralClient.PROVIDER_ID)) {
+      if (StringUtils.isNotBlank(apiKeys.get(providerId)) && clientFor(providerId).isPresent()) {
+        return clientFor(providerId).get();
+      }
+    }
+    throw new TranslationException(
+        TranslationErrorCode.TRANSLATION_NOT_CONFIGURED,
+        null,
+        "No translation provider API key configured");
+  }
+
+  private java.util.Optional<TranslationProviderClient> clientFor(String providerId) {
+    return clientsById().containsKey(providerId)
+        ? java.util.Optional.of(clientsById().get(providerId))
+        : java.util.Optional.empty();
+  }
+
+  private Map<String, TranslationProviderClient> clientsById() {
+    return translationProviderClients.stream()
+        .collect(Collectors.toMap(TranslationProviderClient::getProviderId, Function.identity()));
+  }
+
+  private TranslationApiKeysDTO maskedKeys() {
+    var apiKeys = tenantAdminControlsService.getTranslationApiKeys();
+    return new TranslationApiKeysDTO()
+        .openrouter(ApiKeyMasker.mask(apiKeys.get(OpenRouterClient.PROVIDER_ID)))
+        .mistral(ApiKeyMasker.mask(apiKeys.get(MistralClient.PROVIDER_ID)));
+  }
+
+  private void assertSuperAdmin() {
+    if (!tenantFacadeAuthorisationService.isSuperAdmin()) {
+      throw new AccessDeniedException("Only super admin can manage translation provider API keys");
+    }
+  }
+}

--- a/src/main/java/com/vi/tenantservice/api/model/TenantAdminControlsSettings.java
+++ b/src/main/java/com/vi/tenantservice/api/model/TenantAdminControlsSettings.java
@@ -1,5 +1,6 @@
 package com.vi.tenantservice.api.model;
 
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,4 +13,12 @@ import lombok.NoArgsConstructor;
 public class TenantAdminControlsSettings {
   boolean permissionsPageEnabled;
   TenantAdminAllowedPermissionTogglesSettings allowedPermissionToggles;
+
+  /**
+   * Platform-global machine-translation provider API keys (provider id -> raw key), e.g.
+   * "openrouter"/"mistral". Stored in the same tenant_admin_controls JSON blob as the other
+   * platform-global admin settings. Never exposed through the TenantAdminControls DTO - dedicated
+   * endpoints return them masked only.
+   */
+  Map<String, String> translationApiKeys;
 }

--- a/src/main/java/com/vi/tenantservice/api/service/TenantAdminControlsService.java
+++ b/src/main/java/com/vi/tenantservice/api/service/TenantAdminControlsService.java
@@ -13,6 +13,8 @@ import com.vi.tenantservice.api.model.TenantDTO;
 import com.vi.tenantservice.api.repository.TenantAdminControlsRepository;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -33,8 +35,39 @@ public class TenantAdminControlsService {
   public TenantAdminControls updateControls(TenantAdminControls tenantAdminControls) {
     TenantAdminControlsSettings controlsSettings =
         tenantConverter.toTenantAdminControlsSettings(tenantAdminControls);
+    // the DTO never carries the translation API keys - preserve the stored ones
+    TenantAdminControlsSettings existingSettings = getControlsSettings();
+    if (existingSettings != null) {
+      controlsSettings.setTranslationApiKeys(existingSettings.getTranslationApiKeys());
+    }
     saveControlsSettings(controlsSettings);
     return tenantConverter.toTenantAdminControls(controlsSettings);
+  }
+
+  /**
+   * Raw machine-translation provider API keys (provider id -> key) from the platform-global admin
+   * controls. Internal use only - admin endpoints must expose keys masked.
+   */
+  public Map<String, String> getTranslationApiKeys() {
+    TenantAdminControlsSettings controlsSettings = getControlsSettings();
+    return controlsSettings != null && controlsSettings.getTranslationApiKeys() != null
+        ? controlsSettings.getTranslationApiKeys()
+        : Map.of();
+  }
+
+  /** Stores the machine-translation API key for a provider in the platform-global controls. */
+  public void setTranslationApiKey(String provider, String apiKey) {
+    TenantAdminControlsSettings controlsSettings = getControlsSettings();
+    if (controlsSettings == null) {
+      controlsSettings = new TenantAdminControlsSettings();
+    }
+    Map<String, String> keys = new HashMap<>();
+    if (controlsSettings.getTranslationApiKeys() != null) {
+      keys.putAll(controlsSettings.getTranslationApiKeys());
+    }
+    keys.put(provider, apiKey);
+    controlsSettings.setTranslationApiKeys(keys);
+    saveControlsSettings(controlsSettings);
   }
 
   public void stripTenantAdminControlsFromTenantDto(MultilingualTenantDTO tenantDTO) {

--- a/src/main/java/com/vi/tenantservice/api/service/translation/ApiKeyMasker.java
+++ b/src/main/java/com/vi/tenantservice/api/service/translation/ApiKeyMasker.java
@@ -1,0 +1,35 @@
+package com.vi.tenantservice.api.service.translation;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Masks provider API keys for admin read endpoints: keys can be set but never read back in full.
+ * Follows the password-type admin field convention (e.g. the SMTP password example "********"), but
+ * keeps a recognisable prefix + the last 4 characters so admins can tell keys apart.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiKeyMasker {
+
+  private static final int PREFIX_LENGTH = 3;
+  private static final int SUFFIX_LENGTH = 4;
+  private static final int MIN_LENGTH_FOR_PARTIAL_REVEAL = 12;
+  private static final String ELLIPSIS = "…";
+
+  /**
+   * Returns e.g. {@code sk-…abcd} for a long key, a fully masked {@code …} for short keys and
+   * {@code null} when no key is configured.
+   */
+  public static String mask(String apiKey) {
+    if (StringUtils.isBlank(apiKey)) {
+      return null;
+    }
+    if (apiKey.length() < MIN_LENGTH_FOR_PARTIAL_REVEAL) {
+      return ELLIPSIS;
+    }
+    return apiKey.substring(0, PREFIX_LENGTH)
+        + ELLIPSIS
+        + apiKey.substring(apiKey.length() - SUFFIX_LENGTH);
+  }
+}

--- a/src/main/java/com/vi/tenantservice/api/service/translation/MistralClient.java
+++ b/src/main/java/com/vi/tenantservice/api/service/translation/MistralClient.java
@@ -1,0 +1,24 @@
+package com.vi.tenantservice.api.service.translation;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/** Mistral chat completions at api.mistral.ai/v1 (OpenAI-compatible). */
+@Component
+public class MistralClient extends OpenAiCompatibleChatClient {
+
+  public static final String PROVIDER_ID = "mistral";
+
+  public MistralClient(
+      @Value("${translation.mistral.base-url:https://api.mistral.ai/v1}") String baseUrl,
+      @Value("${translation.mistral.model:mistral-small-latest}") String model,
+      @Value("${translation.connect-timeout-ms:5000}") long connectTimeoutMillis,
+      @Value("${translation.read-timeout-ms:60000}") long readTimeoutMillis) {
+    super(baseUrl, model, connectTimeoutMillis, readTimeoutMillis);
+  }
+
+  @Override
+  public String getProviderId() {
+    return PROVIDER_ID;
+  }
+}

--- a/src/main/java/com/vi/tenantservice/api/service/translation/OpenAiCompatibleChatClient.java
+++ b/src/main/java/com/vi/tenantservice/api/service/translation/OpenAiCompatibleChatClient.java
@@ -1,0 +1,134 @@
+package com.vi.tenantservice.api.service.translation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Base client for OpenAI-compatible chat-completions APIs (OpenRouter, Mistral). Sends a
+ * translation prompt instructing the model to return only the translated HTML while keeping tags,
+ * structure and attributes untouched, and maps provider failures to typed {@link
+ * TranslationException}s: 401/403 = TRANSLATION_KEY_INVALID, 402 = TRANSLATION_NO_CREDIT, 429 =
+ * TRANSLATION_RATE_LIMITED, timeouts/5xx (and any other transport failure) =
+ * TRANSLATION_PROVIDER_UNAVAILABLE.
+ */
+public abstract class OpenAiCompatibleChatClient implements TranslationProviderClient {
+
+  private static final String SYSTEM_PROMPT =
+      """
+      You are a professional translator for legal and administrative texts. \
+      Translate the HTML fragment provided by the user from %s to %s. \
+      Return ONLY the translated HTML. Keep every HTML tag, attribute and the document \
+      structure exactly as in the input; translate only the human-readable text content. \
+      Do not add explanations, comments or code fences.""";
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final RestTemplate restTemplate;
+  private final String baseUrl;
+  private final String model;
+
+  protected OpenAiCompatibleChatClient(
+      String baseUrl, String model, long connectTimeoutMillis, long readTimeoutMillis) {
+    this.baseUrl = StringUtils.removeEnd(baseUrl, "/");
+    this.model = model;
+    var factory = new SimpleClientHttpRequestFactory();
+    factory.setConnectTimeout(Duration.ofMillis(connectTimeoutMillis));
+    factory.setReadTimeout(Duration.ofMillis(readTimeoutMillis));
+    this.restTemplate = new RestTemplate(factory);
+  }
+
+  @Override
+  public String getModel() {
+    return model;
+  }
+
+  @Override
+  public String translateHtml(String apiKey, String sourceLang, String targetLang, String html) {
+    var headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.setBearerAuth(apiKey);
+    var body =
+        Map.of(
+            "model",
+            model,
+            "temperature",
+            0,
+            "messages",
+            List.of(
+                Map.of(
+                    "role", "system", "content", SYSTEM_PROMPT.formatted(sourceLang, targetLang)),
+                Map.of("role", "user", "content", html)));
+    try {
+      var response =
+          restTemplate.postForEntity(
+              baseUrl + "/chat/completions", new HttpEntity<>(body, headers), String.class);
+      return extractContent(response.getBody());
+    } catch (HttpStatusCodeException e) {
+      throw mapStatusError(e);
+    } catch (ResourceAccessException e) {
+      throw new TranslationException(
+          TranslationErrorCode.TRANSLATION_PROVIDER_UNAVAILABLE,
+          getProviderId(),
+          "Provider " + getProviderId() + " unreachable or timed out: " + e.getMessage());
+    } catch (RestClientException e) {
+      throw new TranslationException(
+          TranslationErrorCode.TRANSLATION_PROVIDER_UNAVAILABLE,
+          getProviderId(),
+          "Unexpected provider error from " + getProviderId() + ": " + e.getMessage());
+    }
+  }
+
+  private TranslationException mapStatusError(HttpStatusCodeException e) {
+    var status = e.getStatusCode().value();
+    var errorCode =
+        switch (status) {
+          case 401, 403 -> TranslationErrorCode.TRANSLATION_KEY_INVALID;
+          case 402 -> TranslationErrorCode.TRANSLATION_NO_CREDIT;
+          case 429 -> TranslationErrorCode.TRANSLATION_RATE_LIMITED;
+          default -> TranslationErrorCode.TRANSLATION_PROVIDER_UNAVAILABLE;
+        };
+    return new TranslationException(
+        errorCode, getProviderId(), "Provider " + getProviderId() + " returned HTTP " + status);
+  }
+
+  private String extractContent(String responseBody) {
+    try {
+      JsonNode content = objectMapper.readTree(responseBody).at("/choices/0/message/content");
+      if (content.isMissingNode() || content.isNull()) {
+        throw new TranslationException(
+            TranslationErrorCode.TRANSLATION_PROVIDER_UNAVAILABLE,
+            getProviderId(),
+            "Provider " + getProviderId() + " returned no translation content");
+      }
+      return stripCodeFences(content.asText());
+    } catch (TranslationException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new TranslationException(
+          TranslationErrorCode.TRANSLATION_PROVIDER_UNAVAILABLE,
+          getProviderId(),
+          "Could not parse response of provider " + getProviderId());
+    }
+  }
+
+  /** Defensively removes markdown code fences some models wrap their output in. */
+  private static String stripCodeFences(String content) {
+    var trimmed = content.strip();
+    if (trimmed.startsWith("```")) {
+      trimmed = trimmed.replaceFirst("^```[a-zA-Z]*\\R?", "");
+      trimmed = StringUtils.removeEnd(trimmed.stripTrailing(), "```").stripTrailing();
+    }
+    return trimmed;
+  }
+}

--- a/src/main/java/com/vi/tenantservice/api/service/translation/OpenRouterClient.java
+++ b/src/main/java/com/vi/tenantservice/api/service/translation/OpenRouterClient.java
@@ -1,0 +1,24 @@
+package com.vi.tenantservice.api.service.translation;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/** OpenRouter (OpenAI-compatible chat completions at openrouter.ai/api/v1). */
+@Component
+public class OpenRouterClient extends OpenAiCompatibleChatClient {
+
+  public static final String PROVIDER_ID = "openrouter";
+
+  public OpenRouterClient(
+      @Value("${translation.openrouter.base-url:https://openrouter.ai/api/v1}") String baseUrl,
+      @Value("${translation.openrouter.model:openai/gpt-4o-mini}") String model,
+      @Value("${translation.connect-timeout-ms:5000}") long connectTimeoutMillis,
+      @Value("${translation.read-timeout-ms:60000}") long readTimeoutMillis) {
+    super(baseUrl, model, connectTimeoutMillis, readTimeoutMillis);
+  }
+
+  @Override
+  public String getProviderId() {
+    return PROVIDER_ID;
+  }
+}

--- a/src/main/java/com/vi/tenantservice/api/service/translation/TranslationErrorCode.java
+++ b/src/main/java/com/vi/tenantservice/api/service/translation/TranslationErrorCode.java
@@ -1,0 +1,23 @@
+package com.vi.tenantservice.api.service.translation;
+
+/**
+ * Typed machine-translation error codes exposed to the Admin UI so it can show a clear, actionable
+ * message instead of a generic failure.
+ */
+public enum TranslationErrorCode {
+
+  /** No API key is configured for the requested (or any) provider. Mapped to HTTP 409. */
+  TRANSLATION_NOT_CONFIGURED,
+
+  /** The provider rejected the configured API key (401/403). Mapped to HTTP 502. */
+  TRANSLATION_KEY_INVALID,
+
+  /** The provider account has no credit left (402). Mapped to HTTP 502. */
+  TRANSLATION_NO_CREDIT,
+
+  /** The provider rate limit was hit (429). Mapped to HTTP 502. */
+  TRANSLATION_RATE_LIMITED,
+
+  /** Provider timeout, connection failure or 5xx. Mapped to HTTP 502. */
+  TRANSLATION_PROVIDER_UNAVAILABLE
+}

--- a/src/main/java/com/vi/tenantservice/api/service/translation/TranslationException.java
+++ b/src/main/java/com/vi/tenantservice/api/service/translation/TranslationException.java
@@ -1,0 +1,20 @@
+package com.vi.tenantservice.api.service.translation;
+
+import lombok.Getter;
+
+/**
+ * Signals a machine-translation failure with a typed {@link TranslationErrorCode} so the controller
+ * can map it to a structured 409/502 response the Admin UI understands.
+ */
+@Getter
+public class TranslationException extends RuntimeException {
+
+  private final TranslationErrorCode errorCode;
+  private final transient String provider;
+
+  public TranslationException(TranslationErrorCode errorCode, String provider, String message) {
+    super(message);
+    this.errorCode = errorCode;
+    this.provider = provider;
+  }
+}

--- a/src/main/java/com/vi/tenantservice/api/service/translation/TranslationProviderClient.java
+++ b/src/main/java/com/vi/tenantservice/api/service/translation/TranslationProviderClient.java
@@ -1,0 +1,19 @@
+package com.vi.tenantservice.api.service.translation;
+
+/** A machine-translation provider (LLM chat-completions API) able to translate HTML content. */
+public interface TranslationProviderClient {
+
+  /** Stable provider id used in the settings map and the API ("openrouter", "mistral"). */
+  String getProviderId();
+
+  /** The model this client sends requests for (configurable via application properties). */
+  String getModel();
+
+  /**
+   * Translates one HTML snippet, preserving tags, attributes and structure; only human-readable
+   * text is translated.
+   *
+   * @throws TranslationException with a typed error code on any provider failure
+   */
+  String translateHtml(String apiKey, String sourceLang, String targetLang, String html);
+}

--- a/src/main/java/com/vi/tenantservice/api/util/TranslationMetaUtil.java
+++ b/src/main/java/com/vi/tenantservice/api/util/TranslationMetaUtil.java
@@ -1,0 +1,120 @@
+package com.vi.tenantservice.api.util;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Machine-translation metadata convention for multilingual JSON content maps (language -> HTML,
+ * e.g. the tenant DPA content): a machine translated language carries a parallel meta key inside
+ * the SAME map, e.g. {@code "en__meta": "{\"mt\":true,\"src\":\"de\",\"at\":\"<ISO-timestamp>\"}"}.
+ * No schema change is needed - the convention fits the existing LONGTEXT JSON maps. Meta values are
+ * strict JSON objects with only the known fields {@code mt} (boolean), {@code src} (string) and
+ * {@code at} (string). See documentation/translation-meta.md.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TranslationMetaUtil {
+
+  public static final String META_KEY_SUFFIX = "__meta";
+
+  private static final String FIELD_MT = "mt";
+  private static final String FIELD_SRC = "src";
+  private static final String FIELD_AT = "at";
+  private static final Set<String> KNOWN_FIELDS = Set.of(FIELD_MT, FIELD_SRC, FIELD_AT);
+
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
+
+  /** The meta key for a language, e.g. {@code en -> en__meta}. */
+  public static String metaKeyFor(String language) {
+    return language + META_KEY_SUFFIX;
+  }
+
+  /** Whether the given map key is a meta key ({@code en__meta}) rather than a language key. */
+  public static boolean isMetaKey(String key) {
+    return key != null && key.endsWith(META_KEY_SUFFIX);
+  }
+
+  /** The language a meta key belongs to, e.g. {@code en__meta -> en}. */
+  public static String languageOf(String metaKey) {
+    return StringUtils.removeEnd(metaKey, META_KEY_SUFFIX);
+  }
+
+  /**
+   * Builds the strict meta JSON, e.g. {@code {"mt":true,"src":"de","at":"2026-07-03T10:15:30Z"}}.
+   */
+  public static String buildMeta(String sourceLang, LocalDateTime at) {
+    var node = OBJECT_MAPPER.createObjectNode();
+    node.put(FIELD_MT, true);
+    node.put(FIELD_SRC, sourceLang);
+    node.put(FIELD_AT, at.atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+    return node.toString();
+  }
+
+  /**
+   * Validates a meta value as a strict JSON object containing only the known fields: {@code mt}
+   * (boolean, required), {@code src} (string, optional), {@code at} (string, optional). Unknown
+   * fields, wrong types, non-objects and malformed JSON are rejected.
+   */
+  public static boolean isValidMeta(String metaJson) {
+    if (StringUtils.isBlank(metaJson)) {
+      return false;
+    }
+    JsonNode node;
+    try {
+      node = OBJECT_MAPPER.readTree(metaJson);
+    } catch (Exception e) {
+      return false;
+    }
+    if (node == null
+        || !node.isObject()
+        || !node.has(FIELD_MT)
+        || !node.get(FIELD_MT).isBoolean()) {
+      return false;
+    }
+    var fieldNames = node.fieldNames();
+    while (fieldNames.hasNext()) {
+      var field = fieldNames.next();
+      if (!KNOWN_FIELDS.contains(field)) {
+        return false;
+      }
+    }
+    return (!node.has(FIELD_SRC) || node.get(FIELD_SRC).isTextual())
+        && (!node.has(FIELD_AT) || node.get(FIELD_AT).isTextual());
+  }
+
+  /** Whether the given meta value marks the language as machine translated ({@code mt:true}). */
+  public static boolean isMachineTranslated(String metaJson) {
+    if (!isValidMeta(metaJson)) {
+      return false;
+    }
+    try {
+      return OBJECT_MAPPER.readTree(metaJson).get(FIELD_MT).asBoolean();
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  /** Returns a copy of the map without any meta keys (content-only view). */
+  public static Map<String, String> stripMetaKeys(Map<String, String> contentByLanguage) {
+    var result = new LinkedHashMap<String, String>();
+    if (contentByLanguage != null) {
+      contentByLanguage.forEach(
+          (key, value) -> {
+            if (!isMetaKey(key)) {
+              result.put(key, value);
+            }
+          });
+    }
+    return result;
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,6 +34,16 @@ tenant.cors.allowed.paths=${TENANT_CORS_ALLOWED_PATHS:/tenant/public/**}
 
 app.base.url=
 
+# ---------------- Machine translation (legal texts) ----------------
+# Provider API keys are stored as platform-global admin settings (tenant_admin_controls),
+# managed via /tenantadmin/translation/keys - only the endpoints and model defaults live here.
+translation.openrouter.base-url=${TRANSLATION_OPENROUTER_BASE_URL:https://openrouter.ai/api/v1}
+translation.openrouter.model=${TRANSLATION_OPENROUTER_MODEL:openai/gpt-4o-mini}
+translation.mistral.base-url=${TRANSLATION_MISTRAL_BASE_URL:https://api.mistral.ai/v1}
+translation.mistral.model=${TRANSLATION_MISTRAL_MODEL:mistral-small-latest}
+translation.connect-timeout-ms=${TRANSLATION_CONNECT_TIMEOUT_MS:5000}
+translation.read-timeout-ms=${TRANSLATION_READ_TIMEOUT_MS:60000}
+
 # Springfox/API documentation
 springfox.docuTitle=TenantService
 springfox.docuDescription=Provides a REST API service to provide tenant information and actions.

--- a/src/test/java/com/vi/tenantservice/api/controller/TenantControllerDpaConfirmTest.java
+++ b/src/test/java/com/vi/tenantservice/api/controller/TenantControllerDpaConfirmTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import com.vi.tenantservice.api.facade.TenantDpaFacade;
 import com.vi.tenantservice.api.facade.TenantServiceFacade;
+import com.vi.tenantservice.api.facade.TranslationFacade;
 import com.vi.tenantservice.api.model.DpaGateStatusDTO;
 import com.vi.tenantservice.api.model.DpaSignInviteDTO;
 import com.vi.tenantservice.api.model.DpaSignatureDTO;
@@ -37,6 +38,7 @@ class TenantControllerDpaConfirmTest {
   @Mock private TenantDtoMapper tenantDtoMapper;
   @Mock private TenantDpaService tenantDpaService;
   @Mock private TenantDpaFacade tenantDpaFacade;
+  @Mock private TranslationFacade translationFacade;
   @InjectMocks private TenantController controller;
 
   @Test

--- a/src/test/java/com/vi/tenantservice/api/controller/TenantControllerIT.java
+++ b/src/test/java/com/vi/tenantservice/api/controller/TenantControllerIT.java
@@ -953,4 +953,60 @@ class TenantControllerIT {
         .andExpect(jsonPath("$[0].beraterCount").exists())
         .andExpect(jsonPath("$[0].adminEmails").doesNotExist());
   }
+
+  // --- machine-translation provider API keys (platform-global, super admin only) ---
+
+  private void givenSuperAdminAccessToken() {
+    when(authorisationService.findTenantIdInAccessToken()).thenReturn(Optional.of(0L));
+    when(authorisationService.hasRole("tenant-admin")).thenReturn(true);
+  }
+
+  @Test
+  void translationApiKeys_Should_beStoredViaPut_andOnlyEverReadBackMasked() throws Exception {
+    givenSuperAdminAccessToken();
+    var builder = new AuthenticationMockBuilder();
+
+    mockMvc
+        .perform(
+            put("/tenantadmin/translation/keys/openrouter")
+                .with(authentication(builder.withUserRole(TENANT_ADMIN.getValue()).build()))
+                .contentType(APPLICATION_JSON)
+                .content("{\"apiKey\":\"sk-or-v1-0123456789abcd\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("openrouter", is("sk-\u2026abcd")));
+
+    mockMvc
+        .perform(
+            get("/tenantadmin/translation/keys")
+                .with(authentication(builder.withUserRole(TENANT_ADMIN.getValue()).build())))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("openrouter", is("sk-\u2026abcd")))
+        .andExpect(jsonPath("mistral", is((String) null)));
+  }
+
+  @Test
+  void getTranslationApiKeys_Should_returnForbidden_When_tokenIsNotSuperAdmin() throws Exception {
+    when(authorisationService.findTenantIdInAccessToken()).thenReturn(Optional.of(1L));
+    var builder = new AuthenticationMockBuilder();
+
+    mockMvc
+        .perform(
+            get("/tenantadmin/translation/keys")
+                .with(authentication(builder.withUserRole(TENANT_ADMIN.getValue()).build())))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void setTranslationApiKey_Should_returnForbidden_When_calledWithoutTenantAdminAuthority()
+      throws Exception {
+    mockMvc
+        .perform(
+            put("/tenantadmin/translation/keys/openrouter")
+                .with(
+                    user("not important")
+                        .authorities((GrantedAuthority) SINGLE_TENANT_ADMIN::getValue))
+                .contentType(APPLICATION_JSON)
+                .content("{\"apiKey\":\"sk-or-v1-0123456789abcd\"}"))
+        .andExpect(status().isForbidden());
+  }
 }

--- a/src/test/java/com/vi/tenantservice/api/facade/TenantDpaFacadeTest.java
+++ b/src/test/java/com/vi/tenantservice/api/facade/TenantDpaFacadeTest.java
@@ -17,6 +17,7 @@ import com.vi.tenantservice.api.model.TenantEntity;
 import com.vi.tenantservice.api.service.DpaNotPublishedException;
 import com.vi.tenantservice.api.service.TenantDpaService;
 import com.vi.tenantservice.api.service.TenantService;
+import com.vi.tenantservice.api.util.JsonConverter;
 import com.vi.tenantservice.api.validation.InputSanitizer;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -211,5 +212,114 @@ class TenantDpaFacadeTest {
     assertThatThrownBy(() -> tenantDpaFacade.publishDpa(5L, Map.of("de", "x")))
         .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
     verify(tenantDpaService, never()).recordPublishedVersion(any(), any(), any());
+  }
+
+  // --- machine-translation metadata convention (documentation/translation-meta.md) ---
+
+  private static final String META_EN =
+      "{\"mt\":true,\"src\":\"de\",\"at\":\"2026-07-03T10:15:30Z\"}";
+
+  private TenantEntity givenTenantWithStoredDpa(Map<String, String> storedMap) {
+    var tenant = new TenantEntity();
+    if (storedMap != null) {
+      tenant.setContentDataProcessingAgreement(JsonConverter.convertToJson(storedMap));
+    }
+    when(tenantService.findTenantById(5L)).thenReturn(Optional.of(tenant));
+    return tenant;
+  }
+
+  private void givenIdentitySanitizer() {
+    when(inputSanitizer.sanitizeAllowingFormattingAndLinks(any()))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+  }
+
+  private Map<String, String> storedMapOf(TenantEntity tenant) {
+    return JsonConverter.convertMapFromJson(tenant.getContentDataProcessingAgreement());
+  }
+
+  @Test
+  void publishDpa_Should_acceptAndStoreMetaKeys_withoutSanitizingThem() {
+    var tenant = givenTenantWithStoredDpa(null);
+    givenIdentitySanitizer();
+
+    tenantDpaFacade.publishDpa(5L, Map.of("en", "<p>Hello</p>", "en__meta", META_EN));
+
+    var stored = storedMapOf(tenant);
+    assertThat(stored).containsEntry("en", "<p>Hello</p>").containsEntry("en__meta", META_EN);
+    // the sanitizer must never see the meta value
+    verify(inputSanitizer, never()).sanitizeAllowingFormattingAndLinks(META_EN);
+  }
+
+  @Test
+  void publishDpa_Should_rejectInvalidMeta_withBadRequest() {
+    givenTenantWithStoredDpa(null);
+
+    assertThatThrownBy(
+            () ->
+                tenantDpaFacade.publishDpa(
+                    5L, Map.of("en", "<p>x</p>", "en__meta", "{\"mt\":true,\"evil\":\"field\"}")))
+        .isInstanceOfSatisfying(
+            org.springframework.web.server.ResponseStatusException.class,
+            e ->
+                assertThat(e.getStatusCode())
+                    .isEqualTo(org.springframework.http.HttpStatus.BAD_REQUEST));
+    verify(tenantDpaService, never()).recordPublishedVersion(any(), any(), any());
+  }
+
+  @Test
+  void publishDpa_Should_removeMeta_When_manualEditResendsPreviouslyStoredMeta() {
+    // given: "en" is machine translated (mt:true meta stored)
+    var tenant = givenTenantWithStoredDpa(Map.of("en", "<p>machine</p>", "en__meta", META_EN));
+    givenIdentitySanitizer();
+
+    // when: a manual edit changes the HTML but the UI round-trips the old meta unchanged
+    tenantDpaFacade.publishDpa(5L, Map.of("en", "<p>manually edited</p>", "en__meta", META_EN));
+
+    // then: the machine-translated tag is cleared
+    var stored = storedMapOf(tenant);
+    assertThat(stored).containsEntry("en", "<p>manually edited</p>").doesNotContainKey("en__meta");
+  }
+
+  @Test
+  void publishDpa_Should_keepMeta_When_contentUnchangedOnRepublish() {
+    var tenant = givenTenantWithStoredDpa(Map.of("en", "<p>machine</p>", "en__meta", META_EN));
+    givenIdentitySanitizer();
+
+    tenantDpaFacade.publishDpa(5L, Map.of("en", "<p>machine</p>", "en__meta", META_EN));
+
+    assertThat(storedMapOf(tenant)).containsEntry("en__meta", META_EN);
+  }
+
+  @Test
+  void publishDpa_Should_storeNewMeta_When_freshMachineTranslationReplacesContent() {
+    var tenant = givenTenantWithStoredDpa(Map.of("en", "<p>old machine</p>", "en__meta", META_EN));
+    givenIdentitySanitizer();
+    var freshMeta = "{\"mt\":true,\"src\":\"de\",\"at\":\"2026-07-04T08:00:00Z\"}";
+
+    tenantDpaFacade.publishDpa(5L, Map.of("en", "<p>new machine</p>", "en__meta", freshMeta));
+
+    var stored = storedMapOf(tenant);
+    assertThat(stored)
+        .containsEntry("en", "<p>new machine</p>")
+        .containsEntry("en__meta", freshMeta);
+  }
+
+  @Test
+  void publishDpa_Should_dropOrphanMeta_When_languageHasNoContent() {
+    var tenant = givenTenantWithStoredDpa(null);
+
+    tenantDpaFacade.publishDpa(5L, Map.of("en__meta", META_EN));
+
+    assertThat(storedMapOf(tenant)).isEmpty();
+  }
+
+  @Test
+  void publishDpa_Should_clearMeta_When_manualPublishOmitsMeta() {
+    var tenant = givenTenantWithStoredDpa(Map.of("en", "<p>machine</p>", "en__meta", META_EN));
+    givenIdentitySanitizer();
+
+    tenantDpaFacade.publishDpa(5L, Map.of("en", "<p>manual rewrite</p>"));
+
+    assertThat(storedMapOf(tenant)).doesNotContainKey("en__meta");
   }
 }

--- a/src/test/java/com/vi/tenantservice/api/facade/TranslationFacadeTest.java
+++ b/src/test/java/com/vi/tenantservice/api/facade/TranslationFacadeTest.java
@@ -43,6 +43,9 @@ class TranslationFacadeTest {
 
   @BeforeEach
   void setUp() {
+    // provider ids must be stubbed BEFORE construction: the facade builds its
+    // provider map once in the constructor (review feedback: no per-call rebuilds)
+    givenProviderIds();
     translationFacade =
         new TranslationFacade(
             tenantAdminControlsService,
@@ -51,8 +54,8 @@ class TranslationFacadeTest {
   }
 
   private void givenProviderIds() {
-    when(openRouterClient.getProviderId()).thenReturn("openrouter");
-    when(mistralClient.getProviderId()).thenReturn("mistral");
+    org.mockito.Mockito.lenient().when(openRouterClient.getProviderId()).thenReturn("openrouter");
+    org.mockito.Mockito.lenient().when(mistralClient.getProviderId()).thenReturn("mistral");
   }
 
   private void givenSuperAdmin(boolean isSuperAdmin) {
@@ -167,6 +170,27 @@ class TranslationFacadeTest {
     assertThat(response.getModel()).isEqualTo("mistral-small-latest");
     assertThat(response.getTranslations().get("en")).containsEntry("privacy", "<p>Hello</p>");
     assertThat(response.getTranslations().get("fr")).containsEntry("privacy", "<p>Bonjour</p>");
+  }
+
+  @Test
+  void translate_Should_readApiKeysExactlyOnce_toAvoidToctouBetweenResolveAndUse() {
+    givenProviderIds();
+    when(tenantAdminControlsService.getTranslationApiKeys())
+        .thenReturn(Map.of("mistral", MISTRAL_KEY));
+    when(mistralClient.getModel()).thenReturn("mistral-small-latest");
+    when(mistralClient.translateHtml(MISTRAL_KEY, "de", "en", "<p>Hallo</p>"))
+        .thenReturn("<p>Hello</p>");
+
+    translationFacade.translate(
+        new TranslationRequestDTO()
+            .sourceLang("de")
+            .targetLangs(List.of("en"))
+            .provider("mistral")
+            .texts(Map.of("privacy", "<p>Hallo</p>")));
+
+    // the key used for the provider call must be the one validated during resolution —
+    // a second read would reintroduce the time-of-check/time-of-use window
+    verify(tenantAdminControlsService, org.mockito.Mockito.times(1)).getTranslationApiKeys();
   }
 
   @Test

--- a/src/test/java/com/vi/tenantservice/api/facade/TranslationFacadeTest.java
+++ b/src/test/java/com/vi/tenantservice/api/facade/TranslationFacadeTest.java
@@ -1,0 +1,269 @@
+package com.vi.tenantservice.api.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.vi.tenantservice.api.model.TranslationApiKeyUpdateDTO;
+import com.vi.tenantservice.api.model.TranslationRequestDTO;
+import com.vi.tenantservice.api.service.TenantAdminControlsService;
+import com.vi.tenantservice.api.service.translation.TranslationErrorCode;
+import com.vi.tenantservice.api.service.translation.TranslationException;
+import com.vi.tenantservice.api.service.translation.TranslationProviderClient;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.server.ResponseStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class TranslationFacadeTest {
+
+  private static final String OPENROUTER_KEY = "sk-or-v1-0123456789abcd";
+  private static final String MISTRAL_KEY = "mistral-0123456789wxyz";
+
+  @Mock private TenantAdminControlsService tenantAdminControlsService;
+  @Mock private TenantFacadeAuthorisationService tenantFacadeAuthorisationService;
+
+  @Mock(name = "openRouterClient")
+  private TranslationProviderClient openRouterClient;
+
+  @Mock(name = "mistralClient")
+  private TranslationProviderClient mistralClient;
+
+  private TranslationFacade translationFacade;
+
+  @BeforeEach
+  void setUp() {
+    translationFacade =
+        new TranslationFacade(
+            tenantAdminControlsService,
+            tenantFacadeAuthorisationService,
+            List.of(openRouterClient, mistralClient));
+  }
+
+  private void givenProviderIds() {
+    when(openRouterClient.getProviderId()).thenReturn("openrouter");
+    when(mistralClient.getProviderId()).thenReturn("mistral");
+  }
+
+  private void givenSuperAdmin(boolean isSuperAdmin) {
+    when(tenantFacadeAuthorisationService.isSuperAdmin()).thenReturn(isSuperAdmin);
+  }
+
+  @Test
+  void getMaskedApiKeys_Should_returnMaskedKeys_forSuperAdmin() {
+    givenSuperAdmin(true);
+    when(tenantAdminControlsService.getTranslationApiKeys())
+        .thenReturn(Map.of("openrouter", OPENROUTER_KEY, "mistral", MISTRAL_KEY));
+
+    var keys = translationFacade.getMaskedApiKeys();
+
+    assertThat(keys.getOpenrouter()).isEqualTo("sk-…abcd").doesNotContain("0123456789");
+    assertThat(keys.getMistral()).isEqualTo("mis…wxyz").doesNotContain("0123456789");
+  }
+
+  @Test
+  void getMaskedApiKeys_Should_returnNulls_When_noKeysConfigured() {
+    givenSuperAdmin(true);
+    when(tenantAdminControlsService.getTranslationApiKeys()).thenReturn(Map.of());
+
+    var keys = translationFacade.getMaskedApiKeys();
+
+    assertThat(keys.getOpenrouter()).isNull();
+    assertThat(keys.getMistral()).isNull();
+  }
+
+  @Test
+  void getMaskedApiKeys_Should_denyAccess_When_notSuperAdmin() {
+    givenSuperAdmin(false);
+
+    assertThatThrownBy(() -> translationFacade.getMaskedApiKeys())
+        .isInstanceOf(AccessDeniedException.class);
+  }
+
+  @Test
+  void setApiKey_Should_storeTrimmedKey_andReturnMasked() {
+    givenProviderIds();
+    givenSuperAdmin(true);
+    when(tenantAdminControlsService.getTranslationApiKeys())
+        .thenReturn(Map.of("openrouter", OPENROUTER_KEY));
+
+    var keys =
+        translationFacade.setApiKey(
+            "openrouter", new TranslationApiKeyUpdateDTO().apiKey("  " + OPENROUTER_KEY + "  "));
+
+    verify(tenantAdminControlsService).setTranslationApiKey("openrouter", OPENROUTER_KEY);
+    assertThat(keys.getOpenrouter()).isEqualTo("sk-…abcd");
+  }
+
+  @Test
+  void setApiKey_Should_denyAccess_When_notSuperAdmin() {
+    givenSuperAdmin(false);
+
+    assertThatThrownBy(
+            () ->
+                translationFacade.setApiKey(
+                    "openrouter", new TranslationApiKeyUpdateDTO().apiKey("x")))
+        .isInstanceOf(AccessDeniedException.class);
+    verify(tenantAdminControlsService, never()).setTranslationApiKey(any(), any());
+  }
+
+  @Test
+  void setApiKey_Should_rejectUnknownProvider() {
+    givenProviderIds();
+    givenSuperAdmin(true);
+
+    assertThatThrownBy(
+            () ->
+                translationFacade.setApiKey("deepl", new TranslationApiKeyUpdateDTO().apiKey("x")))
+        .isInstanceOfSatisfying(
+            ResponseStatusException.class,
+            e -> assertThat(e.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST));
+  }
+
+  @Test
+  void setApiKey_Should_rejectBlankKey() {
+    givenProviderIds();
+    givenSuperAdmin(true);
+
+    assertThatThrownBy(
+            () ->
+                translationFacade.setApiKey(
+                    "openrouter", new TranslationApiKeyUpdateDTO().apiKey("   ")))
+        .isInstanceOfSatisfying(
+            ResponseStatusException.class,
+            e -> assertThat(e.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST));
+  }
+
+  @Test
+  void translate_Should_useExplicitProvider_andAssembleResponse() {
+    givenProviderIds();
+    when(tenantAdminControlsService.getTranslationApiKeys())
+        .thenReturn(Map.of("mistral", MISTRAL_KEY));
+    when(mistralClient.getModel()).thenReturn("mistral-small-latest");
+    when(mistralClient.translateHtml(MISTRAL_KEY, "de", "en", "<p>Hallo</p>"))
+        .thenReturn("<p>Hello</p>");
+    when(mistralClient.translateHtml(MISTRAL_KEY, "de", "fr", "<p>Hallo</p>"))
+        .thenReturn("<p>Bonjour</p>");
+
+    var response =
+        translationFacade.translate(
+            new TranslationRequestDTO()
+                .sourceLang("de")
+                .targetLangs(List.of("en", "fr"))
+                .provider("mistral")
+                .texts(Map.of("privacy", "<p>Hallo</p>")));
+
+    assertThat(response.getProvider()).isEqualTo("mistral");
+    assertThat(response.getModel()).isEqualTo("mistral-small-latest");
+    assertThat(response.getTranslations().get("en")).containsEntry("privacy", "<p>Hello</p>");
+    assertThat(response.getTranslations().get("fr")).containsEntry("privacy", "<p>Bonjour</p>");
+  }
+
+  @Test
+  void translate_Should_preferOpenrouter_When_noExplicitProvider_andBothKeysSet() {
+    givenProviderIds();
+    when(tenantAdminControlsService.getTranslationApiKeys())
+        .thenReturn(Map.of("openrouter", OPENROUTER_KEY, "mistral", MISTRAL_KEY));
+    when(openRouterClient.getModel()).thenReturn("openai/gpt-4o-mini");
+    when(openRouterClient.translateHtml(OPENROUTER_KEY, "de", "en", "<p>Hallo</p>"))
+        .thenReturn("<p>Hello</p>");
+
+    var response =
+        translationFacade.translate(
+            new TranslationRequestDTO()
+                .sourceLang("de")
+                .targetLangs(List.of("en"))
+                .texts(Map.of("privacy", "<p>Hallo</p>")));
+
+    assertThat(response.getProvider()).isEqualTo("openrouter");
+    verify(mistralClient, never()).translateHtml(any(), any(), any(), any());
+  }
+
+  @Test
+  void translate_Should_fallBackToMistral_When_onlyMistralKeySet() {
+    givenProviderIds();
+    when(tenantAdminControlsService.getTranslationApiKeys())
+        .thenReturn(Map.of("mistral", MISTRAL_KEY));
+    when(mistralClient.getModel()).thenReturn("mistral-small-latest");
+    when(mistralClient.translateHtml(MISTRAL_KEY, "de", "en", "<p>Hallo</p>"))
+        .thenReturn("<p>Hello</p>");
+
+    var response =
+        translationFacade.translate(
+            new TranslationRequestDTO()
+                .sourceLang("de")
+                .targetLangs(List.of("en"))
+                .texts(Map.of("privacy", "<p>Hallo</p>")));
+
+    assertThat(response.getProvider()).isEqualTo("mistral");
+  }
+
+  @Test
+  void translate_Should_throwNotConfigured_When_noKeySetAtAll() {
+    when(tenantAdminControlsService.getTranslationApiKeys()).thenReturn(Map.of());
+
+    assertThatThrownBy(
+            () ->
+                translationFacade.translate(
+                    new TranslationRequestDTO()
+                        .sourceLang("de")
+                        .targetLangs(List.of("en"))
+                        .texts(Map.of("privacy", "<p>x</p>"))))
+        .isInstanceOfSatisfying(
+            TranslationException.class,
+            e ->
+                assertThat(e.getErrorCode())
+                    .isEqualTo(TranslationErrorCode.TRANSLATION_NOT_CONFIGURED));
+  }
+
+  @Test
+  void translate_Should_throwNotConfigured_When_explicitProviderHasNoKey() {
+    givenProviderIds();
+    when(tenantAdminControlsService.getTranslationApiKeys())
+        .thenReturn(Map.of("mistral", MISTRAL_KEY));
+
+    assertThatThrownBy(
+            () ->
+                translationFacade.translate(
+                    new TranslationRequestDTO()
+                        .sourceLang("de")
+                        .targetLangs(List.of("en"))
+                        .provider("openrouter")
+                        .texts(Map.of("privacy", "<p>x</p>"))))
+        .isInstanceOfSatisfying(
+            TranslationException.class,
+            e -> {
+              assertThat(e.getErrorCode())
+                  .isEqualTo(TranslationErrorCode.TRANSLATION_NOT_CONFIGURED);
+              assertThat(e.getProvider()).isEqualTo("openrouter");
+            });
+  }
+
+  @Test
+  void translate_Should_rejectUnknownExplicitProvider() {
+    givenProviderIds();
+    when(tenantAdminControlsService.getTranslationApiKeys()).thenReturn(Map.of());
+
+    assertThatThrownBy(
+            () ->
+                translationFacade.translate(
+                    new TranslationRequestDTO()
+                        .sourceLang("de")
+                        .targetLangs(List.of("en"))
+                        .provider("deepl")
+                        .texts(Map.of("privacy", "<p>x</p>"))))
+        .isInstanceOfSatisfying(
+            ResponseStatusException.class,
+            e -> assertThat(e.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST));
+  }
+}

--- a/src/test/java/com/vi/tenantservice/api/service/TenantAdminControlsServiceTest.java
+++ b/src/test/java/com/vi/tenantservice/api/service/TenantAdminControlsServiceTest.java
@@ -106,4 +106,75 @@ class TenantAdminControlsServiceTest {
     verify(tenantAdminControlsRepository).save(captor.capture());
     assertThat(captor.getValue().getControls()).contains("groupChat");
   }
+
+  // --- machine-translation provider API keys (stored in the same controls JSON blob) ---
+
+  private void givenStoredControlsJson(String controlsJson) {
+    when(tenantAdminControlsRepository.findTopByOrderByIdAsc())
+        .thenReturn(
+            Optional.of(TenantAdminControlsEntity.builder().id(1L).controls(controlsJson).build()));
+  }
+
+  private String capturedSavedControls() {
+    ArgumentCaptor<TenantAdminControlsEntity> captor =
+        ArgumentCaptor.forClass(TenantAdminControlsEntity.class);
+    verify(tenantAdminControlsRepository).save(captor.capture());
+    return captor.getValue().getControls();
+  }
+
+  @Test
+  void getTranslationApiKeys_Should_returnEmptyMap_When_noKeysStored() {
+    givenStoredControlsJson("{\"permissionsPageEnabled\":true}");
+
+    assertThat(tenantAdminControlsService.getTranslationApiKeys()).isEmpty();
+  }
+
+  @Test
+  void getTranslationApiKeys_Should_returnStoredKeys() {
+    givenStoredControlsJson(
+        "{\"permissionsPageEnabled\":true,"
+            + "\"translationApiKeys\":{\"openrouter\":\"sk-or-key\",\"mistral\":\"mi-key\"}}");
+
+    assertThat(tenantAdminControlsService.getTranslationApiKeys())
+        .containsEntry("openrouter", "sk-or-key")
+        .containsEntry("mistral", "mi-key");
+  }
+
+  @Test
+  void setTranslationApiKey_Should_persistKeyInControlsJson() {
+    givenStoredControlsJson("{\"permissionsPageEnabled\":true}");
+
+    tenantAdminControlsService.setTranslationApiKey("openrouter", "sk-or-new-key");
+
+    assertThat(capturedSavedControls())
+        .contains("\"openrouter\":\"sk-or-new-key\"")
+        .contains("\"permissionsPageEnabled\":true");
+  }
+
+  @Test
+  void setTranslationApiKey_Should_keepOtherProviderKey() {
+    givenStoredControlsJson(
+        "{\"permissionsPageEnabled\":true,\"translationApiKeys\":{\"mistral\":\"mi-key\"}}");
+
+    tenantAdminControlsService.setTranslationApiKey("openrouter", "sk-or-new-key");
+
+    assertThat(capturedSavedControls())
+        .contains("\"mistral\":\"mi-key\"")
+        .contains("\"openrouter\":\"sk-or-new-key\"");
+  }
+
+  @Test
+  void updateControls_Should_preserveStoredTranslationApiKeys() {
+    givenStoredControlsJson(
+        "{\"permissionsPageEnabled\":true,\"translationApiKeys\":{\"openrouter\":\"sk-or-key\"}}");
+    TenantAdminControls request = new TenantAdminControls().permissionsPageEnabled(false);
+    when(tenantConverter.toTenantAdminControlsSettings(request))
+        .thenReturn(TenantAdminControlsSettings.builder().permissionsPageEnabled(false).build());
+    when(tenantConverter.toTenantAdminControls(any(TenantAdminControlsSettings.class)))
+        .thenReturn(request);
+
+    tenantAdminControlsService.updateControls(request);
+
+    assertThat(capturedSavedControls()).contains("\"openrouter\":\"sk-or-key\"");
+  }
 }

--- a/src/test/java/com/vi/tenantservice/api/service/translation/ApiKeyMaskerTest.java
+++ b/src/test/java/com/vi/tenantservice/api/service/translation/ApiKeyMaskerTest.java
@@ -1,0 +1,31 @@
+package com.vi.tenantservice.api.service.translation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ApiKeyMaskerTest {
+
+  @Test
+  void mask_Should_showPrefixAndLast4_forLongKeys() {
+    assertThat(ApiKeyMasker.mask("sk-or-v1-0123456789abcd")).isEqualTo("sk-…abcd");
+  }
+
+  @Test
+  void mask_Should_neverContainTheMiddleOfTheKey() {
+    var masked = ApiKeyMasker.mask("sk-or-v1-SECRETSECRETSECRET1234");
+    assertThat(masked).doesNotContain("SECRET").isEqualTo("sk-…1234");
+  }
+
+  @Test
+  void mask_Should_fullyMaskShortKeys() {
+    assertThat(ApiKeyMasker.mask("short")).isEqualTo("…");
+  }
+
+  @Test
+  void mask_Should_returnNull_When_noKeyConfigured() {
+    assertThat(ApiKeyMasker.mask(null)).isNull();
+    assertThat(ApiKeyMasker.mask("   ")).isNull();
+    assertThat(ApiKeyMasker.mask("")).isNull();
+  }
+}

--- a/src/test/java/com/vi/tenantservice/api/service/translation/OpenAiCompatibleChatClientTest.java
+++ b/src/test/java/com/vi/tenantservice/api/service/translation/OpenAiCompatibleChatClientTest.java
@@ -1,0 +1,211 @@
+package com.vi.tenantservice.api.service.translation;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Provider tests against a local WireMock (no real network calls): both providers, every typed
+ * error code mapping Frank asked for.
+ */
+class OpenAiCompatibleChatClientTest {
+
+  private static final String CHAT_COMPLETIONS = "/chat/completions";
+  private static final long CONNECT_TIMEOUT_MS = 1000;
+  private static final long READ_TIMEOUT_MS = 1500;
+
+  private static WireMockServer wireMock;
+
+  @BeforeAll
+  static void startWireMock() {
+    wireMock = new WireMockServer(wireMockConfig().dynamicPort());
+    wireMock.start();
+  }
+
+  @AfterAll
+  static void stopWireMock() {
+    wireMock.stop();
+  }
+
+  @BeforeEach
+  void resetWireMock() {
+    wireMock.resetAll();
+  }
+
+  static Stream<Arguments> providers() {
+    return Stream.of(
+        Arguments.of(
+            "openrouter",
+            (Function<String, TranslationProviderClient>)
+                baseUrl ->
+                    new OpenRouterClient(
+                        baseUrl, "openai/gpt-4o-mini", CONNECT_TIMEOUT_MS, READ_TIMEOUT_MS)),
+        Arguments.of(
+            "mistral",
+            (Function<String, TranslationProviderClient>)
+                baseUrl ->
+                    new MistralClient(
+                        baseUrl, "mistral-small-latest", CONNECT_TIMEOUT_MS, READ_TIMEOUT_MS)));
+  }
+
+  private static TranslationProviderClient client(
+      Function<String, TranslationProviderClient> factory) {
+    return factory.apply(wireMock.baseUrl());
+  }
+
+  private static void stubStatus(int status) {
+    wireMock.stubFor(
+        post(urlEqualTo(CHAT_COMPLETIONS))
+            .willReturn(aResponse().withStatus(status).withBody("{\"error\":\"provider error\"}")));
+  }
+
+  private static void stubSuccess(String content) {
+    wireMock.stubFor(
+        post(urlEqualTo(CHAT_COMPLETIONS))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        "{\"choices\":[{\"message\":{\"role\":\"assistant\",\"content\":"
+                            + com.fasterxml.jackson.databind.node.TextNode.valueOf(content)
+                            + "}}]}")));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("providers")
+  void translateHtml_Should_returnTranslatedHtml_andSendBearerKeyAndModel(
+      String providerId, Function<String, TranslationProviderClient> factory) {
+    stubSuccess("<p>Hello world</p>");
+
+    var result = client(factory).translateHtml("test-key", "de", "en", "<p>Hallo Welt</p>");
+
+    assertThat(result).isEqualTo("<p>Hello world</p>");
+    wireMock.verify(
+        postRequestedFor(urlEqualTo(CHAT_COMPLETIONS))
+            .withHeader("Authorization", equalTo("Bearer test-key"))
+            .withRequestBody(matchingJsonPath("$.model"))
+            .withRequestBody(matchingJsonPath("$.messages[0].content"))
+            .withRequestBody(
+                matchingJsonPath("$.messages[1].content", equalTo("<p>Hallo Welt</p>"))));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("providers")
+  void translateHtml_Should_stripCodeFences_When_modelWrapsOutput(
+      String providerId, Function<String, TranslationProviderClient> factory) {
+    stubSuccess("```html\n<p>Hello</p>\n```");
+
+    var result = client(factory).translateHtml("test-key", "de", "en", "<p>Hallo</p>");
+
+    assertThat(result).isEqualTo("<p>Hello</p>");
+  }
+
+  @ParameterizedTest(name = "{0} 401")
+  @MethodSource("providers")
+  void translateHtml_Should_mapUnauthorized_toKeyInvalid(
+      String providerId, Function<String, TranslationProviderClient> factory) {
+    stubStatus(401);
+    assertTranslationError(factory, TranslationErrorCode.TRANSLATION_KEY_INVALID, providerId);
+  }
+
+  @ParameterizedTest(name = "{0} 403")
+  @MethodSource("providers")
+  void translateHtml_Should_mapForbidden_toKeyInvalid(
+      String providerId, Function<String, TranslationProviderClient> factory) {
+    stubStatus(403);
+    assertTranslationError(factory, TranslationErrorCode.TRANSLATION_KEY_INVALID, providerId);
+  }
+
+  @ParameterizedTest(name = "{0} 402")
+  @MethodSource("providers")
+  void translateHtml_Should_mapPaymentRequired_toNoCredit(
+      String providerId, Function<String, TranslationProviderClient> factory) {
+    stubStatus(402);
+    assertTranslationError(factory, TranslationErrorCode.TRANSLATION_NO_CREDIT, providerId);
+  }
+
+  @ParameterizedTest(name = "{0} 429")
+  @MethodSource("providers")
+  void translateHtml_Should_mapTooManyRequests_toRateLimited(
+      String providerId, Function<String, TranslationProviderClient> factory) {
+    stubStatus(429);
+    assertTranslationError(factory, TranslationErrorCode.TRANSLATION_RATE_LIMITED, providerId);
+  }
+
+  @ParameterizedTest(name = "{0} 500")
+  @MethodSource("providers")
+  void translateHtml_Should_mapServerError_toProviderUnavailable(
+      String providerId, Function<String, TranslationProviderClient> factory) {
+    stubStatus(500);
+    assertTranslationError(
+        factory, TranslationErrorCode.TRANSLATION_PROVIDER_UNAVAILABLE, providerId);
+  }
+
+  @ParameterizedTest(name = "{0} 503")
+  @MethodSource("providers")
+  void translateHtml_Should_mapServiceUnavailable_toProviderUnavailable(
+      String providerId, Function<String, TranslationProviderClient> factory) {
+    stubStatus(503);
+    assertTranslationError(
+        factory, TranslationErrorCode.TRANSLATION_PROVIDER_UNAVAILABLE, providerId);
+  }
+
+  @ParameterizedTest(name = "{0} timeout")
+  @MethodSource("providers")
+  void translateHtml_Should_mapReadTimeout_toProviderUnavailable(
+      String providerId, Function<String, TranslationProviderClient> factory) {
+    wireMock.stubFor(
+        post(urlEqualTo(CHAT_COMPLETIONS))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withFixedDelay((int) READ_TIMEOUT_MS + 2000)
+                    .withBody("{}")));
+
+    assertTranslationError(
+        factory, TranslationErrorCode.TRANSLATION_PROVIDER_UNAVAILABLE, providerId);
+  }
+
+  @ParameterizedTest(name = "{0} malformed body")
+  @MethodSource("providers")
+  void translateHtml_Should_mapMissingContent_toProviderUnavailable(
+      String providerId, Function<String, TranslationProviderClient> factory) {
+    wireMock.stubFor(
+        post(urlEqualTo(CHAT_COMPLETIONS))
+            .willReturn(aResponse().withStatus(200).withBody("{\"unexpected\":true}")));
+
+    assertTranslationError(
+        factory, TranslationErrorCode.TRANSLATION_PROVIDER_UNAVAILABLE, providerId);
+  }
+
+  private static void assertTranslationError(
+      Function<String, TranslationProviderClient> factory,
+      TranslationErrorCode expectedCode,
+      String expectedProvider) {
+    var client = client(factory);
+    assertThatThrownBy(() -> client.translateHtml("test-key", "de", "en", "<p>x</p>"))
+        .isInstanceOfSatisfying(
+            TranslationException.class,
+            e -> {
+              assertThat(e.getErrorCode()).isEqualTo(expectedCode);
+              assertThat(e.getProvider()).isEqualTo(expectedProvider);
+            });
+  }
+}

--- a/src/test/java/com/vi/tenantservice/api/util/TranslationMetaUtilTest.java
+++ b/src/test/java/com/vi/tenantservice/api/util/TranslationMetaUtilTest.java
@@ -1,0 +1,95 @@
+package com.vi.tenantservice.api.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TranslationMetaUtilTest {
+
+  @Test
+  void metaKeyFor_Should_appendMetaSuffix() {
+    assertThat(TranslationMetaUtil.metaKeyFor("en")).isEqualTo("en__meta");
+  }
+
+  @Test
+  void isMetaKey_Should_detectMetaKeys() {
+    assertThat(TranslationMetaUtil.isMetaKey("en__meta")).isTrue();
+    assertThat(TranslationMetaUtil.isMetaKey("en")).isFalse();
+    assertThat(TranslationMetaUtil.isMetaKey(null)).isFalse();
+  }
+
+  @Test
+  void languageOf_Should_stripMetaSuffix() {
+    assertThat(TranslationMetaUtil.languageOf("en__meta")).isEqualTo("en");
+  }
+
+  @Test
+  void buildMeta_Should_produceValidStrictJson_withSourceAndTimestamp() {
+    var meta = TranslationMetaUtil.buildMeta("de", LocalDateTime.of(2026, 7, 3, 10, 15, 30));
+
+    assertThat(TranslationMetaUtil.isValidMeta(meta)).isTrue();
+    assertThat(TranslationMetaUtil.isMachineTranslated(meta)).isTrue();
+    assertThat(meta)
+        .contains("\"mt\":true")
+        .contains("\"src\":\"de\"")
+        .contains("2026-07-03T10:15:30");
+  }
+
+  @Test
+  void isValidMeta_Should_acceptStrictJsonWithKnownFieldsOnly() {
+    assertThat(
+            TranslationMetaUtil.isValidMeta(
+                "{\"mt\":true,\"src\":\"de\",\"at\":\"2026-07-03T10:15:30Z\"}"))
+        .isTrue();
+    assertThat(TranslationMetaUtil.isValidMeta("{\"mt\":false}")).isTrue();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "not json at all",
+        "[]",
+        "\"string\"",
+        "{}",
+        "{\"src\":\"de\"}",
+        "{\"mt\":\"yes\"}",
+        "{\"mt\":true,\"extra\":\"field\"}",
+        "{\"mt\":true,\"src\":1}",
+        "{\"mt\":true,\"at\":42}",
+        "{\"mt\":true,\"src\":\"de\"} trailing",
+        ""
+      })
+  void isValidMeta_Should_rejectMalformedOrUnknownOrWrongTypedFields(String metaJson) {
+    assertThat(TranslationMetaUtil.isValidMeta(metaJson)).isFalse();
+  }
+
+  @Test
+  void isMachineTranslated_Should_beFalse_When_mtFalseOrInvalid() {
+    assertThat(TranslationMetaUtil.isMachineTranslated("{\"mt\":false}")).isFalse();
+    assertThat(TranslationMetaUtil.isMachineTranslated("garbage")).isFalse();
+    assertThat(TranslationMetaUtil.isMachineTranslated(null)).isFalse();
+  }
+
+  @Test
+  void stripMetaKeys_Should_removeOnlyMetaKeys_andPreserveOrder() {
+    Map<String, String> map = new LinkedHashMap<>();
+    map.put("de", "<p>de</p>");
+    map.put("en", "<p>en</p>");
+    map.put("en__meta", "{\"mt\":true}");
+
+    var stripped = TranslationMetaUtil.stripMetaKeys(map);
+
+    assertThat(stripped).containsOnlyKeys("de", "en");
+    assertThat(stripped.keySet()).containsExactly("de", "en");
+  }
+
+  @Test
+  void stripMetaKeys_Should_returnEmptyMap_When_inputNull() {
+    assertThat(TranslationMetaUtil.stripMetaKeys(null)).isEmpty();
+  }
+}


### PR DESCRIPTION
## What this enables

Admins can machine-translate legal texts (DPA, privacy, imprint) with their own **OpenRouter** or **Mistral** API key. When the key is broken, out of credit or rate-limited, the Admin UI gets a clear, typed error instead of a generic failure. Translated languages are tagged as "machine translated" until a human edits them.

## Endpoints

| Method | Path | Auth | Purpose |
|---|---|---|---|
| PUT | `/tenantadmin/translation/keys/{provider}` | Super admin | Set the API key for `openrouter` or `mistral` |
| GET | `/tenantadmin/translation/keys` | Super admin | Read keys back **masked** (`sk-…abcd`), never in full |
| POST | `/tenantadmin/translate` | `Authority.UPDATE_TENANT` | Translate HTML texts into one or more target languages |

Keys are stored in the existing platform-global `tenant_admin_controls` JSON blob — **no DB schema change**. Provider is picked explicitly or by default order: openrouter if its key is set, else mistral. Models are configurable (`translation.openrouter.model`, default `openai/gpt-4o-mini`; `translation.mistral.model`, default `mistral-small-latest`).

## Typed error codes

| Provider response | Error code | HTTP |
|---|---|---|
| no key configured | `TRANSLATION_NOT_CONFIGURED` | 409 |
| 401 / 403 | `TRANSLATION_KEY_INVALID` | 502 |
| 402 / credit exhausted | `TRANSLATION_NO_CREDIT` | 502 |
| 429 | `TRANSLATION_RATE_LIMITED` | 502 |
| timeout / 5xx | `TRANSLATION_PROVIDER_UNAVAILABLE` | 502 |

The code is returned in the response body (`errorCode`, `provider`, `message`) so the Admin UI can show a clear message.

## The meta convention (3 sentences)

Legal content is stored as a JSON map `language -> HTML`; a machine-translated language gets a parallel key **inside the same map**, e.g. `"en__meta": "{\"mt\":true,\"src\":\"de\",\"at\":\"<ISO-timestamp>\"}"`. The DPA publish path validates meta values as strict JSON (only `mt`/`src`/`at`) and stores them without HTML-sanitizing. When a human manually edits a language that is tagged `mt:true`, the tag is removed — manual edits clear the machine-translated flag. Details: `documentation/translation-meta.md`.

## Also fixed on the way

`TenantControllerIT` was fully broken on dev (every request failed with Hibernate Validator `HV000151` since the Spring Boot 4 upgrade, hidden because CI does not run `*IT`). Root cause: the controller re-declared `@Valid` on overridden interface methods. This PR removes the re-declarations (validation still runs via the generated interface annotations), bringing the class from 32 errors down to 5 pre-existing, unrelated failures (H2 `settings` column length + one `adminEmails` serialization assertion, both SB4-upgrade leftovers).

## Test evidence

- `./mvnw -B package` (CI gate, JDK 21): **229 tests, 0 failures**, spotless clean, BUILD SUCCESS
- New coverage:
  - WireMock provider tests for **both** providers x **all** error codes (401/403/402/429/500/503/timeout/malformed body) — no real network calls
  - Facade tests: provider selection order, explicit provider, not-configured, masking, super-admin guard
  - Meta-util tests: strict validation (unknown fields, wrong types, trailing tokens rejected), build/strip
  - Publish-path tests: meta accepted + stored, sanitizer never touches meta, invalid meta -> 400, manual-edit-clears-mt, fresh translation keeps meta, orphan meta dropped
  - Controls-service tests: key persistence, key preserved when toggles are updated
  - Wire-level IT: PUT key -> GET returns `sk-…abcd` (masked), 403 for non-super-admins — all three new IT tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
