### PR TITLE
[codex] Fix tenant access authorization failures

### DIFF
--- a/src/main/java/com/vi/tenantservice/api/facade/TenantFacadeAuthorisationService.java
+++ b/src/main/java/com/vi/tenantservice/api/facade/TenantFacadeAuthorisationService.java
@@ -178,7 +178,7 @@ public class TenantFacadeAuthorisationService {
   }
 
   public boolean canAccessTenant(Optional<TenantEntity> tenant) {
-    if (isSuperAdmin() || multitenancyWithSingleDomain) {
+    if (multitenancyWithSingleDomain || isSuperAdmin()) {
       return true;
     }
 
@@ -191,25 +191,35 @@ public class TenantFacadeAuthorisationService {
       boolean result = tenantMatching(tenant.get().getId(), tenantIdInAccessToken);
 
       // Temporary workaround: always return true for technical user
-      if ("technical".equals(authorisationService.getUsername())) {
+      if (isTechnicalUser()) {
         return true;
       }
 
       return result;
     } catch (Exception e) {
+      log.debug("Could not determine tenant access from access token", e);
       // Temporary workaround: always return true for technical user
-      if ("technical".equals(authorisationService.getUsername())) {
-        return true;
-      }
-      return false;
+      return isTechnicalUser();
     }
   }
 
   public boolean isSuperAdmin() {
-    var tenantId = authorisationService.findTenantIdInAccessToken();
-    if (tenantId.isEmpty() || !tenantId.get().equals(0L)) {
+    try {
+      Optional<Long> tenantId = authorisationService.findTenantIdInAccessToken();
+      return tenantId.filter(id -> id.equals(0L)).isPresent()
+          && authorisationService.hasRole("tenant-admin");
+    } catch (Exception e) {
+      log.debug("Could not determine tenant id from access token while checking super admin", e);
       return false;
     }
-    return authorisationService.hasRole("tenant-admin");
+  }
+
+  private boolean isTechnicalUser() {
+    try {
+      return "technical".equals(authorisationService.getUsername());
+    } catch (Exception e) {
+      log.debug("Could not determine username from access token while checking technical user", e);
+      return false;
+    }
   }
 }

--- a/src/main/java/com/vi/tenantservice/config/security/AuthorisationService.java
+++ b/src/main/java/com/vi/tenantservice/config/security/AuthorisationService.java
@@ -4,7 +4,6 @@ import com.google.common.collect.Lists;
 import com.vi.tenantservice.api.authorisation.RoleAuthorizationAuthorityMapper;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -87,11 +86,14 @@ public class AuthorisationService {
   }
 
   public Collection<String> extractRealmRoles(Jwt jwt) {
-    Map<String, Object> realmAccess = (Map<String, Object>) jwt.getClaims().get("realm_access");
-    if (realmAccess != null) {
-      var roles = (List<String>) realmAccess.get("roles");
-      if (roles != null) {
-        return roles;
+    Object realmAccess = jwt.getClaims().get("realm_access");
+    if (realmAccess instanceof Map<?, ?> realmAccessMap) {
+      Object roles = realmAccessMap.get("roles");
+      if (roles instanceof Collection<?> roleCollection) {
+        return roleCollection.stream()
+            .filter(String.class::isInstance)
+            .map(String.class::cast)
+            .toList();
       }
     }
     return Lists.newArrayList();

--- a/src/test/java/com/vi/tenantservice/api/facade/TenantFacadeAuthorisationServiceTest.java
+++ b/src/test/java/com/vi/tenantservice/api/facade/TenantFacadeAuthorisationServiceTest.java
@@ -2,6 +2,7 @@ package com.vi.tenantservice.api.facade;
 
 import static com.vi.tenantservice.api.authorisation.UserRole.SINGLE_TENANT_ADMIN;
 import static com.vi.tenantservice.api.authorisation.UserRole.TENANT_ADMIN;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -67,6 +68,23 @@ class TenantFacadeAuthorisationServiceTest {
           // when
           tenantFacadeAuthorisationService.assertUserIsAuthorizedToAccessTenant(ID);
         });
+  }
+
+  @Test
+  void canAccessTenant_Should_ReturnFalse_When_TenantIdCannotBeReadFromAccessToken() {
+    // given
+    when(authorisationService.findTenantIdInAccessToken())
+        .thenThrow(new AccessDeniedException("tenantId attribute not found in the access token"));
+    when(authorisationService.getUsername())
+        .thenThrow(new AccessDeniedException("Invalid encoded username claim in JWT token"));
+
+    // when
+    boolean canAccessTenant =
+        tenantFacadeAuthorisationService.canAccessTenant(
+            Optional.of(TenantEntity.builder().id(ID).build()));
+
+    // then
+    assertThat(canAccessTenant).isFalse();
   }
 
   @Test

--- a/src/test/java/com/vi/tenantservice/config/security/AuthorisationServiceTest.java
+++ b/src/test/java/com/vi/tenantservice/config/security/AuthorisationServiceTest.java
@@ -101,6 +101,33 @@ class AuthorisationServiceTest {
   }
 
   @Test
+  void extractRealmRoles_Should_ReturnNoRoles_WhenRealmAccessClaimHasUnexpectedType() {
+    // given
+    when(jwt.getClaims()).thenReturn(new HashMap<>(Map.of("realm_access", "invalid")));
+
+    // when
+    Collection<String> roles = authorisationService.extractRealmRoles(jwt);
+
+    // then
+    assertThat(roles).isEmpty();
+  }
+
+  @Test
+  void extractRealmRoles_Should_IgnoreNonStringRoleValues() {
+    // given
+    when(jwt.getClaims())
+        .thenReturn(
+            new HashMap<>(
+                Map.of("realm_access", Map.of("roles", Lists.newArrayList(1, "tenant-admin")))));
+
+    // when
+    Collection<String> roles = authorisationService.extractRealmRoles(jwt);
+
+    // then
+    assertThat(roles).containsExactly("tenant-admin");
+  }
+
+  @Test
   void extractRealmRoles_Should_ExtractAuthoritiesFromJwt() {
     // given
     when(jwt.getClaims())

--- a/src/test/java/com/vi/tenantservice/config/security/JwtAuthConverterTest.java
+++ b/src/test/java/com/vi/tenantservice/config/security/JwtAuthConverterTest.java
@@ -1,0 +1,51 @@
+package com.vi.tenantservice.config.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+class JwtAuthConverterTest {
+
+  private final JwtAuthConverterProperties properties = new JwtAuthConverterProperties();
+  private final JwtAuthConverter jwtAuthConverter =
+      new JwtAuthConverter(properties, new AuthorisationService());
+
+  @Test
+  void convert_Should_NotThrow_WhenRealmAccessClaimHasUnexpectedType() {
+    // given
+    Jwt jwt = jwtWithClaims(Map.of("sub", "user-id", "realm_access", "invalid"));
+
+    // when, then
+    assertThatCode(() -> jwtAuthConverter.convert(jwt)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void convert_Should_IgnoreNonStringRoleValues_WhenRealmAccessRolesAreMixed() {
+    // given
+    Jwt jwt =
+        jwtWithClaims(
+            Map.of("sub", "user-id", "realm_access", Map.of("roles", List.of(42, "tenant-admin"))));
+
+    // when
+    JwtAuthenticationToken authenticationToken =
+        (JwtAuthenticationToken) jwtAuthConverter.convert(jwt);
+
+    // then
+    assertThat(authenticationToken.getAuthorities())
+        .extracting("authority")
+        .contains("AUTHORIZATION_GET_ALL_TENANTS");
+  }
+
+  private Jwt jwtWithClaims(Map<String, Object> claims) {
+    Map<String, Object> headers = new HashMap<>();
+    headers.put("alg", "none");
+    return new Jwt("token", Instant.now(), Instant.now().plusSeconds(60), headers, claims);
+  }
+}


### PR DESCRIPTION
## Summary

- Harden /tenant/access authorization checks so malformed or missing tenant/user claims deny access instead of bubbling into a 500.
- Make JWT realm_access parsing tolerant of unexpected claim shapes and non-string role values.
- Add regression tests for tenant access fallback behavior and JWT authority conversion.

## Root Cause

The tenant access check and JWT authority extraction could throw unchecked exceptions while reading token claims. For the admin login access probe, those exceptions could surface as a server error instead of returning an authorization response.

## Validation

- ./mvnw test — 166 tests passed
- External smoke checks returned 401, not 500, for unauthenticated and malformed-token requests to https://api.oriso.org/service/tenant/access.

## Notes

Authenticated production behavior should be verified after deployment with a valid production session/token.