### PR TITLE
[codex] Fix tenant controller validation constraints

### DIFF
--- a/src/main/java/com/vi/tenantservice/api/controller/TenantController.java
+++ b/src/main/java/com/vi/tenantservice/api/controller/TenantController.java
@@ -21,6 +21,10 @@ import com.vi.tenantservice.config.security.AuthorisationService;
 import com.vi.tenantservice.generated.api.controller.TenantApi;
 import com.vi.tenantservice.generated.api.controller.TenantadminApi;
 import io.swagger.annotations.Api;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -60,7 +64,7 @@ public class TenantController implements TenantApi, TenantadminApi {
    */
   @Override
   public ResponseEntity<DpaSignatureDTO> confirmDataProcessingAgreement(
-      String token, DpaSignatureRequestDTO request) {
+      @NotNull String token, @Valid DpaSignatureRequestDTO request) {
     if (!Boolean.TRUE.equals(request.getAccepted())) {
       return ResponseEntity.badRequest().build();
     }
@@ -97,32 +101,34 @@ public class TenantController implements TenantApi, TenantadminApi {
 
   @Override
   @PreAuthorize("hasAuthority('AUTHORIZATION_GET_TENANT')")
-  public ResponseEntity<List<DpaSignatureDTO>> getDataProcessingAgreementSignatures(Long id) {
+  public ResponseEntity<List<DpaSignatureDTO>> getDataProcessingAgreementSignatures(
+      @NotNull Long id) {
     return new ResponseEntity<>(tenantDpaFacade.getSignatures(id), HttpStatus.OK);
   }
 
   @Override
   @PreAuthorize("hasAuthority('AUTHORIZATION_GET_TENANT')")
-  public ResponseEntity<DpaGateStatusDTO> getDataProcessingAgreementGate(Long id) {
+  public ResponseEntity<DpaGateStatusDTO> getDataProcessingAgreementGate(@NotNull Long id) {
     return new ResponseEntity<>(tenantDpaFacade.getGateStatus(id), HttpStatus.OK);
   }
 
   @Override
   @PreAuthorize("hasAuthority('AUTHORIZATION_GET_TENANT')")
-  public ResponseEntity<List<DpaVersionDTO>> getDataProcessingAgreementVersions(Long id) {
+  public ResponseEntity<List<DpaVersionDTO>> getDataProcessingAgreementVersions(@NotNull Long id) {
     return new ResponseEntity<>(tenantDpaFacade.getVersions(id), HttpStatus.OK);
   }
 
   @Override
   @PreAuthorize("hasAuthority('AUTHORIZATION_UPDATE_TENANT')")
-  public ResponseEntity<DpaSignInviteDTO> createDataProcessingAgreementSignInvite(Long id) {
+  public ResponseEntity<DpaSignInviteDTO> createDataProcessingAgreementSignInvite(
+      @NotNull Long id) {
     return new ResponseEntity<>(tenantDpaFacade.createSignInvite(id), HttpStatus.OK);
   }
 
   @Override
   @PreAuthorize("hasAuthority('AUTHORIZATION_UPDATE_TENANT')")
   public ResponseEntity<DpaGateStatusDTO> publishDataProcessingAgreement(
-      Long id, Map<String, String> requestBody) {
+      @NotNull Long id, @Valid Map<String, String> requestBody) {
     return new ResponseEntity<>(tenantDpaFacade.publishDpa(id, requestBody), HttpStatus.OK);
   }
 
@@ -134,7 +140,7 @@ public class TenantController implements TenantApi, TenantadminApi {
 
   @Override
   @PreAuthorize("hasAuthority('AUTHORIZATION_GET_TENANT')")
-  public ResponseEntity<TenantDTO> getTenantById(Long id) {
+  public ResponseEntity<TenantDTO> getTenantById(@NotNull Long id) {
 
     var tenantById = tenantServiceFacade.findTenantById(id);
     return tenantById.isEmpty()
@@ -160,14 +166,14 @@ public class TenantController implements TenantApi, TenantadminApi {
   @Override
   @PreAuthorize("hasAuthority('AUTHORIZATION_GET_ALL_TENANTS')")
   public ResponseEntity<TenantAdminControls> updateTenantAdminControls(
-      @jakarta.validation.Valid TenantAdminControls tenantAdminControls) {
+      @Valid TenantAdminControls tenantAdminControls) {
     return new ResponseEntity<>(
         tenantServiceFacade.updateTenantAdminControls(tenantAdminControls), HttpStatus.OK);
   }
 
   @Override
   @PreAuthorize("hasAuthority('AUTHORIZATION_GET_TENANT')")
-  public ResponseEntity<MultilingualTenantDTO> getMultilingualTenantById(Long id) {
+  public ResponseEntity<MultilingualTenantDTO> getMultilingualTenantById(@NotNull Long id) {
     var tenantById = tenantServiceFacade.findMultilingualTenantById(id);
     return tenantById.isEmpty()
         ? new ResponseEntity<>(HttpStatus.NOT_FOUND)
@@ -177,7 +183,7 @@ public class TenantController implements TenantApi, TenantadminApi {
   @Override
   @PreAuthorize("hasAuthority('AUTHORIZATION_CREATE_TENANT')")
   public ResponseEntity<MultilingualTenantDTO> createTenant(
-      @jakarta.validation.Valid MultilingualTenantDTO tenantMultilingualDTO) {
+      @Valid MultilingualTenantDTO tenantMultilingualDTO) {
     log.info("Creating tenant by user {} ", authorisationService.getUsername());
     var tenant = tenantServiceFacade.createTenant(tenantMultilingualDTO);
     return new ResponseEntity<>(tenant, HttpStatus.OK);
@@ -186,7 +192,7 @@ public class TenantController implements TenantApi, TenantadminApi {
   @Override
   @PreAuthorize("hasAuthority('AUTHORIZATION_UPDATE_TENANT')")
   public ResponseEntity<MultilingualTenantDTO> updateTenant(
-      Long id, @jakarta.validation.Valid MultilingualTenantDTO tenantDTO) {
+      @NotNull Long id, @Valid MultilingualTenantDTO tenantDTO) {
     log.info("Updating tenant with id {} by user {} ", id, authorisationService.getUsername());
     var updatedTenantDTO = tenantServiceFacade.updateTenant(id, tenantDTO);
     return new ResponseEntity<>(updatedTenantDTO, HttpStatus.OK);
@@ -202,7 +208,7 @@ public class TenantController implements TenantApi, TenantadminApi {
 
   @Override
   public ResponseEntity<RestrictedTenantDTO> getRestrictedTenantDataBySubdomain(
-      String subdomain, Long tenantId) {
+      @NotNull String subdomain, @Valid Long tenantId) {
     var tenantById = tenantServiceFacade.findTenantBySubdomain(subdomain, tenantId);
     return tenantById.isEmpty()
         ? new ResponseEntity<>(HttpStatus.NOT_FOUND)
@@ -210,7 +216,8 @@ public class TenantController implements TenantApi, TenantadminApi {
   }
 
   @Override
-  public ResponseEntity<RestrictedTenantDTO> getRestrictedTenantDataByTenantId(Long tenantId) {
+  public ResponseEntity<RestrictedTenantDTO> getRestrictedTenantDataByTenantId(
+      @NotNull Long tenantId) {
     var tenantById = tenantServiceFacade.findRestrictedTenantById(tenantId);
     return tenantById.isEmpty()
         ? new ResponseEntity<>(HttpStatus.NOT_FOUND)
@@ -247,7 +254,11 @@ public class TenantController implements TenantApi, TenantadminApi {
   @Override
   @PreAuthorize("hasAuthority('AUTHORIZATION_SEARCH_TENANTS')")
   public ResponseEntity<TenantsSearchResultDTO> searchTenants(
-      String query, Integer page, Integer perPage, String field, String order) {
+      @NotNull @Valid String query,
+      @Min(1) @Valid Integer page,
+      @Min(1) @Valid Integer perPage,
+      @Pattern(regexp = "^(NAME|ID)$") @Valid String field,
+      @Pattern(regexp = "^(ASC|DESC)$") @Valid String order) {
     var decodedInfix = URLDecoder.decode(query, StandardCharsets.UTF_8).trim();
     var isAscending = order.equalsIgnoreCase("asc");
     var mappedField = tenantDtoMapper.mappedFieldOf(field);


### PR DESCRIPTION
## Summary
- Align TenantController override parameter validation annotations with the generated OpenAPI interfaces
- Fix Hibernate Validator HV000151 metadata failure that caused GET /tenant/access to return 500 after deployment

## Tests
- ./mvnw '-Dtest=TenantControllerIT#canAccessTenant*' test
- ./mvnw test