### PR TITLE
[codex] Avoid full tenant load in access check

### DIFF
--- a/src/main/java/com/vi/tenantservice/api/facade/TenantFacadeAuthorisationService.java
+++ b/src/main/java/com/vi/tenantservice/api/facade/TenantFacadeAuthorisationService.java
@@ -178,17 +178,21 @@ public class TenantFacadeAuthorisationService {
   }
 
   public boolean canAccessTenant(Optional<TenantEntity> tenant) {
+    return canAccessTenantById(tenant.map(TenantEntity::getId));
+  }
+
+  public boolean canAccessTenantById(Optional<Long> tenantId) {
     if (multitenancyWithSingleDomain || isSuperAdmin()) {
       return true;
     }
 
-    if (tenant.isEmpty()) {
+    if (tenantId.isEmpty()) {
       return false;
     }
 
     try {
       var tenantIdInAccessToken = authorisationService.findTenantIdInAccessToken();
-      boolean result = tenantMatching(tenant.get().getId(), tenantIdInAccessToken);
+      boolean result = tenantMatching(tenantId.get(), tenantIdInAccessToken);
 
       // Temporary workaround: always return true for technical user
       if (isTechnicalUser()) {

--- a/src/main/java/com/vi/tenantservice/api/facade/TenantServiceFacade.java
+++ b/src/main/java/com/vi/tenantservice/api/facade/TenantServiceFacade.java
@@ -516,8 +516,8 @@ public class TenantServiceFacade {
       }
     }
 
-    var tenantBySubdomain = tenantService.findTenantBySubdomain(subdomain.get());
-    return tenantFacadeAuthorisationService.canAccessTenant(tenantBySubdomain);
+    var tenantIdBySubdomain = tenantService.findTenantIdBySubdomain(subdomain.get());
+    return tenantFacadeAuthorisationService.canAccessTenantById(tenantIdBySubdomain);
   }
 
   public Map<String, Object> findTenantsExceptTechnicalByInfix(

--- a/src/main/java/com/vi/tenantservice/api/repository/TenantRepository.java
+++ b/src/main/java/com/vi/tenantservice/api/repository/TenantRepository.java
@@ -7,10 +7,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TenantRepository extends JpaRepository<TenantEntity, Long> {
 
   TenantEntity findBySubdomain(String subdomain);
+
+  @Query("SELECT t.id FROM TenantEntity t WHERE t.subdomain = :subdomain")
+  Long findIdBySubdomain(@Param("subdomain") String subdomain);
 
   @Query(
       value =

--- a/src/main/java/com/vi/tenantservice/api/service/TenantService.java
+++ b/src/main/java/com/vi/tenantservice/api/service/TenantService.java
@@ -124,6 +124,10 @@ public class TenantService {
     return bySubdomain != null ? Optional.of(bySubdomain) : Optional.empty();
   }
 
+  public Optional<Long> findTenantIdBySubdomain(String subdomain) {
+    return Optional.ofNullable(tenantRepository.findIdBySubdomain(subdomain));
+  }
+
   public List<TenantEntity> getAllTenants() {
     return tenantRepository.findAll();
   }

--- a/src/test/java/com/vi/tenantservice/api/facade/TenantServiceFacadeTest.java
+++ b/src/test/java/com/vi/tenantservice/api/facade/TenantServiceFacadeTest.java
@@ -512,6 +512,22 @@ class TenantServiceFacadeTest {
     assertThat(tenantDTO.get().getContent().getPrivacy()).contains("content2");
   }
 
+  @Test
+  void canAccessTenant_Should_useTenantIdLookupInsteadOfLoadingTenantEntity() {
+    // given
+    when(subdomainExtractor.getCurrentSubdomain()).thenReturn(Optional.of("localhost"));
+    when(tenantService.findTenantIdBySubdomain("localhost")).thenReturn(Optional.of(3L));
+    when(tenantFacadeAuthorisationService.canAccessTenantById(Optional.of(3L))).thenReturn(true);
+
+    // when
+    boolean canAccessTenant = tenantServiceFacade.canAccessTenant();
+
+    // then
+    assertThat(canAccessTenant).isTrue();
+    verify(tenantService).findTenantIdBySubdomain("localhost");
+    verify(tenantService, never()).findTenantBySubdomain("localhost");
+  }
+
   private static Optional<TenantEntity> getTenantWithPrivacy(String contentPrivacy) {
     TenantEntity defaultTenantEntity = new TenantEntity();
     defaultTenantEntity.setContentPrivacy(contentPrivacy);


### PR DESCRIPTION
## Summary
- Change GET /tenant/access to resolve tenant access using an id-only subdomain lookup
- Avoid loading the full TenantEntity for the access probe, so the query no longer selects content_dpa on environments where that DPA migration has not been applied yet
- Add a regression test ensuring canAccessTenant uses the id lookup instead of findTenantBySubdomain

## Tests
- ./mvnw '-Dtest=TenantServiceFacadeTest,TenantFacadeAuthorisationServiceTest,TenantControllerIT#canAccessTenant*' test
- ./mvnw spotless:apply test