### PR TITLE
[codex] Avoid DPA columns in public tenant reads

### DIFF
--- a/src/main/java/com/vi/tenantservice/api/converter/TenantConverter.java
+++ b/src/main/java/com/vi/tenantservice/api/converter/TenantConverter.java
@@ -27,6 +27,7 @@ import com.vi.tenantservice.api.model.TenantAdminControlsSettings;
 import com.vi.tenantservice.api.model.TenantDTO;
 import com.vi.tenantservice.api.model.TenantEntity;
 import com.vi.tenantservice.api.model.TenantEntity.TenantEntityBuilder;
+import com.vi.tenantservice.api.model.TenantRestrictedData;
 import com.vi.tenantservice.api.model.TenantSettings;
 import com.vi.tenantservice.api.model.TenantSmtpSettings;
 import com.vi.tenantservice.api.model.Theming;
@@ -214,7 +215,7 @@ public class TenantConverter {
     return tenantDTO;
   }
 
-  private Settings getSettings(TenantEntity tenant) {
+  private Settings getSettings(TenantRestrictedData tenant) {
     if (tenant.getSettings() == null) {
       return new Settings();
     } else {
@@ -437,7 +438,7 @@ public class TenantConverter {
         .emailThemeColor(smtpSettings.getEmailThemeColor());
   }
 
-  public RestrictedTenantDTO toRestrictedTenantDTO(TenantEntity tenant, String lang) {
+  public RestrictedTenantDTO toRestrictedTenantDTO(TenantRestrictedData tenant, String lang) {
     return new RestrictedTenantDTO(tenant.getId(), tenant.getName())
         .content(toContentDTO(tenant, lang))
         .theming(toThemingDTO(tenant))
@@ -445,7 +446,7 @@ public class TenantConverter {
         .settings(getRestrictedPublicSettings(tenant));
   }
 
-  private Settings getRestrictedPublicSettings(TenantEntity tenant) {
+  private Settings getRestrictedPublicSettings(TenantRestrictedData tenant) {
     Settings settings = getSettings(tenant);
     settings.setFeatureToolsOICDToken(null);
     settings.setSmtp(toPublicSmtpConfig(settings.getSmtp()));
@@ -483,7 +484,7 @@ public class TenantConverter {
     return new Licensing(tenant.getLicensingAllowedNumberOfUsers());
   }
 
-  private Theming toThemingDTO(TenantEntity tenant) {
+  private Theming toThemingDTO(TenantRestrictedData tenant) {
     return new Theming()
         .favicon(tenant.getThemingFavicon())
         .logo(tenant.getThemingLogo())
@@ -492,7 +493,7 @@ public class TenantConverter {
         .secondaryColor(tenant.getThemingSecondaryColor());
   }
 
-  private Content toContentDTO(TenantEntity tenant, String lang) {
+  private Content toContentDTO(TenantRestrictedData tenant, String lang) {
     String privacyPotentiallyWithPlaceholders =
         getTranslatedStringFromMap(tenant.getContentPrivacy(), lang);
     DataProtectionContactTemplateDTO dataProtectionContactTemplate =

--- a/src/main/java/com/vi/tenantservice/api/converter/TenantConverter.java
+++ b/src/main/java/com/vi/tenantservice/api/converter/TenantConverter.java
@@ -25,6 +25,7 @@ import com.vi.tenantservice.api.model.TenantAdminAllowedPermissionTogglesSetting
 import com.vi.tenantservice.api.model.TenantAdminControls;
 import com.vi.tenantservice.api.model.TenantAdminControlsSettings;
 import com.vi.tenantservice.api.model.TenantDTO;
+import com.vi.tenantservice.api.model.TenantData;
 import com.vi.tenantservice.api.model.TenantEntity;
 import com.vi.tenantservice.api.model.TenantEntity.TenantEntityBuilder;
 import com.vi.tenantservice.api.model.TenantRestrictedData;
@@ -177,7 +178,7 @@ public class TenantConverter {
     }
   }
 
-  public MultilingualTenantDTO toMultilingualDTO(TenantEntity tenant) {
+  public MultilingualTenantDTO toMultilingualDTO(TenantData tenant) {
     var tenantDTO =
         new MultilingualTenantDTO(tenant.getName())
             .id(tenant.getId())
@@ -197,7 +198,7 @@ public class TenantConverter {
     return tenantDTO;
   }
 
-  public TenantDTO toDTO(TenantEntity tenant, String lang) {
+  public TenantDTO toDTO(TenantData tenant, String lang) {
     var tenantDTO =
         new TenantDTO(tenant.getId(), tenant.getName(), tenant.getSubdomain())
             .address(tenant.getAddress())
@@ -466,7 +467,7 @@ public class TenantConverter {
         .emailThemeColor(smtpConfig.getEmailThemeColor());
   }
 
-  public BasicTenantLicensingDTO toBasicLicensingTenantDTO(TenantEntity tenant) {
+  public BasicTenantLicensingDTO toBasicLicensingTenantDTO(TenantData tenant) {
     var basicTenantLicensingDTO =
         new BasicTenantLicensingDTO(tenant.getId(), tenant.getName(), tenant.getSubdomain())
             .licensing(toLicensingDTO(tenant));
@@ -480,7 +481,7 @@ public class TenantConverter {
     return basicTenantLicensingDTO;
   }
 
-  public Licensing toLicensingDTO(TenantEntity tenant) {
+  public Licensing toLicensingDTO(TenantData tenant) {
     return new Licensing(tenant.getLicensingAllowedNumberOfUsers());
   }
 
@@ -576,7 +577,7 @@ public class TenantConverter {
     }
   }
 
-  private MultilingualContent toMultilingualContentDTO(TenantEntity tenant) {
+  private MultilingualContent toMultilingualContentDTO(TenantData tenant) {
     return new MultilingualContent(convertMapFromJson(tenant.getContentImpressum()))
         .claim(convertMapFromJson(tenant.getContentClaim()))
         .privacy(convertMapFromJson(tenant.getContentPrivacy()))
@@ -584,7 +585,7 @@ public class TenantConverter {
         .dataProtectionContactTemplate(getMultilingualDataProtectionTemplate());
   }
 
-  public AdminTenantDTO toAdminTenantDTO(TenantEntity tenant) {
+  public AdminTenantDTO toAdminTenantDTO(TenantData tenant) {
     var adminTenantDTO =
         new AdminTenantDTO(tenant.getId(), tenant.getName(), tenant.getSubdomain())
             .address(tenant.getAddress())

--- a/src/main/java/com/vi/tenantservice/api/facade/TenantServiceFacade.java
+++ b/src/main/java/com/vi/tenantservice/api/facade/TenantServiceFacade.java
@@ -22,8 +22,8 @@ import com.vi.tenantservice.api.model.RestrictedTenantDTO;
 import com.vi.tenantservice.api.model.Settings;
 import com.vi.tenantservice.api.model.TenantAdminControls;
 import com.vi.tenantservice.api.model.TenantDTO;
+import com.vi.tenantservice.api.model.TenantData;
 import com.vi.tenantservice.api.model.TenantEntity;
-import com.vi.tenantservice.api.model.TenantEntity.TenantBase;
 import com.vi.tenantservice.api.model.TenantRestrictedData;
 import com.vi.tenantservice.api.service.SingleDomainTenantOverrideService;
 import com.vi.tenantservice.api.service.TenantAdminControlsService;
@@ -48,8 +48,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -192,7 +190,7 @@ public class TenantServiceFacade {
   }
 
   private boolean onlyTechnicalTenantExists() {
-    List<TenantEntity> tenants = tenantService.getAllTenants();
+    List<TenantData> tenants = tenantService.getAllTenantData();
     return tenants.size() == 1 && tenants.get(0).getId().equals(0L);
   }
 
@@ -328,7 +326,7 @@ public class TenantServiceFacade {
 
   public Optional<TenantDTO> findTenantById(Long id) {
     tenantFacadeAuthorisationService.assertUserIsAuthorizedToAccessTenant(id);
-    var tenantById = tenantService.findTenantById(id);
+    var tenantById = tenantService.findTenantDataById(id);
     if (tenantById.isEmpty()) {
       return Optional.empty();
     }
@@ -338,7 +336,7 @@ public class TenantServiceFacade {
     return Optional.of(tenantDTO);
   }
 
-  private MultilingualTenantDTO getConvertedAndEnrichedTenant(TenantEntity tenantEntity) {
+  private MultilingualTenantDTO getConvertedAndEnrichedTenant(TenantData tenantEntity) {
     var multilingualTenantDTO = tenantConverter.toMultilingualDTO(tenantEntity);
     tenantAdminControlsService.enrichTenantDtoWithTenantAdminControls(multilingualTenantDTO);
     enrichWithAdminDataIfSuperadmin(multilingualTenantDTO);
@@ -409,7 +407,7 @@ public class TenantServiceFacade {
 
   public Optional<MultilingualTenantDTO> findMultilingualTenantById(Long id) {
     tenantFacadeAuthorisationService.assertUserIsAuthorizedToAccessTenant(id);
-    var tenantById = tenantService.findTenantById(id);
+    var tenantById = tenantService.findTenantDataById(id);
     return tenantById.isEmpty()
         ? Optional.empty()
         : Optional.of(getConvertedAndEnrichedTenant(tenantById.get()));
@@ -425,7 +423,7 @@ public class TenantServiceFacade {
   }
 
   public List<BasicTenantLicensingDTO> getAllTenants() {
-    var tenantEntities = tenantService.getAllTenants();
+    var tenantEntities = tenantService.getAllTenantData();
     return tenantEntities.stream().map(tenantConverter::toBasicLicensingTenantDTO).toList();
   }
 
@@ -490,7 +488,7 @@ public class TenantServiceFacade {
   }
 
   public Optional<RestrictedTenantDTO> getSingleTenant() {
-    var tenantEntities = tenantService.getAllTenants();
+    var tenantEntities = tenantService.getAllTenantData();
     if (tenantEntities != null && tenantEntities.size() == 1) {
       var tenantEntity = tenantEntities.get(0);
       String lang = translationService.getCurrentLanguageContext();
@@ -528,14 +526,13 @@ public class TenantServiceFacade {
       String infix, int pageNumber, Integer pageSize, String fieldName, boolean isAscending) {
     var direction = isAscending ? Direction.ASC : Direction.DESC;
     var pageRequest = PageRequest.of(pageNumber, pageSize, direction, fieldName);
-    Page<TenantBase> tenantPage = tenantService.findAllExceptTechnicalByInfix(infix, pageRequest);
-    var tenantIds = tenantPage.stream().map(TenantBase::getId).toList();
-    var fullTenants = tenantService.findAllByIds(tenantIds);
-    return mapOf(tenantPage, fullTenants);
+    Page<TenantData> tenantPage =
+        tenantService.findAllTenantDataExceptTechnicalByInfix(infix, pageRequest);
+    return mapOf(tenantPage);
   }
 
   public List<AdminTenantDTO> getAllAdminTenantsExceptTechnical() {
-    var tenantEntities = tenantService.getAllTenants();
+    var tenantEntities = new ArrayList<>(tenantService.getAllTenantData());
     excludeTechnicalTenantFrom(tenantEntities);
     List<AdminTenantDTO> adminTenantDTOS =
         tenantEntities.stream().map(tenantConverter::toAdminTenantDTO).toList();
@@ -545,19 +542,15 @@ public class TenantServiceFacade {
     return adminTenantDTOS;
   }
 
-  private void excludeTechnicalTenantFrom(List<TenantEntity> tenants) {
+  private void excludeTechnicalTenantFrom(List<? extends TenantData> tenants) {
     emptyIfNull(tenants).removeIf(tenant -> tenant.getId() == TECHNICAL_TENANT_ID);
   }
 
-  private Map<String, Object> mapOf(Page<TenantBase> tenantPage, List<TenantEntity> fullTenants) {
-    var fullTenantsLookupMap =
-        fullTenants.stream().collect(Collectors.toMap(TenantEntity::getId, Function.identity()));
-
+  private Map<String, Object> mapOf(Page<TenantData> tenantPage) {
     var tenants = new ArrayList<Map<String, Object>>();
     tenantPage.forEach(
-        tenantBase -> {
-          var fullTenant = fullTenantsLookupMap.get(tenantBase.getId());
-          var tenantMap = mapOf(tenantBase, fullTenant);
+        tenantData -> {
+          var tenantMap = mapOf(tenantData);
           tenants.add(tenantMap);
         });
 
@@ -572,28 +565,28 @@ public class TenantServiceFacade {
         tenants);
   }
 
-  private Map<String, Object> mapOf(TenantBase tenantBase, TenantEntity fullTenant) {
+  private Map<String, Object> mapOf(TenantData tenantData) {
     Map<String, Object> map = new HashMap<>();
-    map.put("id", tenantBase.getId());
-    map.put("name", tenantBase.getName());
-    map.put("subdomain", fullTenant.getSubdomain());
-    map.put("beraterCount", fullTenant.getLicensingAllowedNumberOfUsers());
+    map.put("id", tenantData.getId());
+    map.put("name", tenantData.getName());
+    map.put("subdomain", tenantData.getSubdomain());
+    map.put("beraterCount", tenantData.getLicensingAllowedNumberOfUsers());
     List<AdminResponseDTO> tenantAdmins = new ArrayList<>();
     try {
-      tenantAdmins = userAdminService.getTenantAdmins(tenantBase.getId().intValue());
+      tenantAdmins = userAdminService.getTenantAdmins(tenantData.getId().intValue());
     } catch (Exception ex) {
       log.warn(
           "Could not resolve tenant-admin emails for tenant {}. Returning tenant without adminEmails.",
-          tenantBase.getId(),
+          tenantData.getId(),
           ex);
     }
     map.put("adminEmails", getAdminEmails(tenantAdmins));
     map.put(
         "createDate",
-        nonNull(fullTenant.getCreateDate()) ? fullTenant.getCreateDate().toString() : null);
+        nonNull(tenantData.getCreateDate()) ? tenantData.getCreateDate().toString() : null);
     map.put(
         "updateDate",
-        nonNull(fullTenant.getUpdateDate()) ? fullTenant.getUpdateDate().toString() : null);
+        nonNull(tenantData.getUpdateDate()) ? tenantData.getUpdateDate().toString() : null);
     return map;
   }
 }

--- a/src/main/java/com/vi/tenantservice/api/facade/TenantServiceFacade.java
+++ b/src/main/java/com/vi/tenantservice/api/facade/TenantServiceFacade.java
@@ -24,6 +24,7 @@ import com.vi.tenantservice.api.model.TenantAdminControls;
 import com.vi.tenantservice.api.model.TenantDTO;
 import com.vi.tenantservice.api.model.TenantEntity;
 import com.vi.tenantservice.api.model.TenantEntity.TenantBase;
+import com.vi.tenantservice.api.model.TenantRestrictedData;
 import com.vi.tenantservice.api.service.SingleDomainTenantOverrideService;
 import com.vi.tenantservice.api.service.TenantAdminControlsService;
 import com.vi.tenantservice.api.service.TenantService;
@@ -415,7 +416,7 @@ public class TenantServiceFacade {
   }
 
   public Optional<RestrictedTenantDTO> findRestrictedTenantById(Long id) {
-    var tenantById = tenantService.findTenantById(id);
+    var tenantById = tenantService.findRestrictedTenantDataById(id);
 
     String lang = translationService.getCurrentLanguageContext();
     return tenantById.isEmpty()
@@ -430,7 +431,7 @@ public class TenantServiceFacade {
 
   public Optional<RestrictedTenantDTO> findTenantBySubdomain(
       String subdomain, Long optionalTenantIdOverride) {
-    var tenantBySubdomain = tenantService.findTenantBySubdomain(subdomain);
+    var tenantBySubdomain = tenantService.findRestrictedTenantDataBySubdomain(subdomain);
     Optional<Long> tenantIdFromRequestOrCookie =
         resolveFromRequestOrCookie(optionalTenantIdOverride);
 
@@ -465,17 +466,20 @@ public class TenantServiceFacade {
             .getApplicationSettings()
             .getMainTenantSubdomainForSingleDomainMultitenancy()
             .getValue();
-    var mainTenant = tenantService.findTenantBySubdomain(mainTenantSubdomain).orElseThrow();
+    var mainTenant =
+        tenantService.findRestrictedTenantDataBySubdomain(mainTenantSubdomain).orElseThrow();
     Long actualTenantId = tenantResolverService.tryResolve().orElseThrow();
-    TenantEntity actualTenant = tenantService.findTenantById(actualTenantId).orElseThrow();
+    TenantRestrictedData actualTenant =
+        tenantService.findRestrictedTenantDataById(actualTenantId).orElseThrow();
     return singleDomainTenantOverrideService.overridePrivacyAndCertainSettings(
         mainTenant, actualTenant);
   }
 
   public Optional<RestrictedTenantDTO> getTenantDataWithOverride(
-      Optional<TenantEntity> mainTenantForSingleDomainMultitenancy, Long resolvedTenantId) {
+      Optional<TenantRestrictedData> mainTenantForSingleDomainMultitenancy, Long resolvedTenantId) {
 
-    Optional<TenantEntity> tenantToOverridePrivacy = tenantService.findTenantById(resolvedTenantId);
+    Optional<TenantRestrictedData> tenantToOverridePrivacy =
+        tenantService.findRestrictedTenantDataById(resolvedTenantId);
     if (tenantToOverridePrivacy.isEmpty()) {
       throw new BadRequestException("Tenant not found for id " + resolvedTenantId);
     }

--- a/src/main/java/com/vi/tenantservice/api/facade/TenantServiceFacade.java
+++ b/src/main/java/com/vi/tenantservice/api/facade/TenantServiceFacade.java
@@ -476,6 +476,10 @@ public class TenantServiceFacade {
   public Optional<RestrictedTenantDTO> getTenantDataWithOverride(
       Optional<TenantRestrictedData> mainTenantForSingleDomainMultitenancy, Long resolvedTenantId) {
 
+    if (mainTenantForSingleDomainMultitenancy.isEmpty()) {
+      return Optional.empty();
+    }
+
     Optional<TenantRestrictedData> tenantToOverridePrivacy =
         tenantService.findRestrictedTenantDataById(resolvedTenantId);
     if (tenantToOverridePrivacy.isEmpty()) {
@@ -483,8 +487,7 @@ public class TenantServiceFacade {
     }
     return Optional.of(
         singleDomainTenantOverrideService.overridePrivacyAndCertainSettings(
-            mainTenantForSingleDomainMultitenancy.orElseThrow(),
-            tenantToOverridePrivacy.orElseThrow()));
+            mainTenantForSingleDomainMultitenancy.get(), tenantToOverridePrivacy.get()));
   }
 
   public Optional<RestrictedTenantDTO> getSingleTenant() {

--- a/src/main/java/com/vi/tenantservice/api/model/TenantData.java
+++ b/src/main/java/com/vi/tenantservice/api/model/TenantData.java
@@ -1,0 +1,16 @@
+package com.vi.tenantservice.api.model;
+
+import java.time.LocalDateTime;
+
+public interface TenantData extends TenantRestrictedData {
+
+  String getAddress();
+
+  String getDescription();
+
+  Integer getLicensingAllowedNumberOfUsers();
+
+  LocalDateTime getCreateDate();
+
+  LocalDateTime getUpdateDate();
+}

--- a/src/main/java/com/vi/tenantservice/api/model/TenantDataView.java
+++ b/src/main/java/com/vi/tenantservice/api/model/TenantDataView.java
@@ -1,0 +1,31 @@
+package com.vi.tenantservice.api.model;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class TenantDataView implements TenantData {
+
+  private final Long id;
+  private final String name;
+  private final String subdomain;
+  private final String address;
+  private final String description;
+  private final Integer licensingAllowedNumberOfUsers;
+  private final String themingLogo;
+  private final String themingAssociationLogo;
+  private final String themingFavicon;
+  private final String themingPrimaryColor;
+  private final String themingSecondaryColor;
+  private final String contentImpressum;
+  private final String contentClaim;
+  private final String contentPrivacy;
+  private final LocalDateTime contentPrivacyActivationDate;
+  private final String contentTermsAndConditions;
+  private final LocalDateTime contentTermsAndConditionsActivationDate;
+  private final String settings;
+  private final LocalDateTime createDate;
+  private final LocalDateTime updateDate;
+}

--- a/src/main/java/com/vi/tenantservice/api/model/TenantEntity.java
+++ b/src/main/java/com/vi/tenantservice/api/model/TenantEntity.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @EqualsAndHashCode
-public class TenantEntity {
+public class TenantEntity implements TenantRestrictedData {
 
   @Id
   @SequenceGenerator(name = "id_seq", allocationSize = 1, sequenceName = "SEQUENCE_TENANT")

--- a/src/main/java/com/vi/tenantservice/api/model/TenantEntity.java
+++ b/src/main/java/com/vi/tenantservice/api/model/TenantEntity.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @EqualsAndHashCode
-public class TenantEntity implements TenantRestrictedData {
+public class TenantEntity implements TenantData {
 
   @Id
   @SequenceGenerator(name = "id_seq", allocationSize = 1, sequenceName = "SEQUENCE_TENANT")

--- a/src/main/java/com/vi/tenantservice/api/model/TenantRestrictedData.java
+++ b/src/main/java/com/vi/tenantservice/api/model/TenantRestrictedData.java
@@ -1,0 +1,36 @@
+package com.vi.tenantservice.api.model;
+
+import java.time.LocalDateTime;
+
+public interface TenantRestrictedData {
+
+  Long getId();
+
+  String getName();
+
+  String getSubdomain();
+
+  String getThemingLogo();
+
+  String getThemingAssociationLogo();
+
+  String getThemingFavicon();
+
+  String getThemingPrimaryColor();
+
+  String getThemingSecondaryColor();
+
+  String getContentImpressum();
+
+  String getContentClaim();
+
+  String getContentPrivacy();
+
+  LocalDateTime getContentPrivacyActivationDate();
+
+  String getContentTermsAndConditions();
+
+  LocalDateTime getContentTermsAndConditionsActivationDate();
+
+  String getSettings();
+}

--- a/src/main/java/com/vi/tenantservice/api/model/TenantRestrictedDataView.java
+++ b/src/main/java/com/vi/tenantservice/api/model/TenantRestrictedDataView.java
@@ -1,0 +1,26 @@
+package com.vi.tenantservice.api.model;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class TenantRestrictedDataView implements TenantRestrictedData {
+
+  private final Long id;
+  private final String name;
+  private final String subdomain;
+  private final String themingLogo;
+  private final String themingAssociationLogo;
+  private final String themingFavicon;
+  private final String themingPrimaryColor;
+  private final String themingSecondaryColor;
+  private final String contentImpressum;
+  private final String contentClaim;
+  private final String contentPrivacy;
+  private final LocalDateTime contentPrivacyActivationDate;
+  private final String contentTermsAndConditions;
+  private final LocalDateTime contentTermsAndConditionsActivationDate;
+  private final String settings;
+}

--- a/src/main/java/com/vi/tenantservice/api/repository/TenantRepository.java
+++ b/src/main/java/com/vi/tenantservice/api/repository/TenantRepository.java
@@ -1,7 +1,7 @@
 package com.vi.tenantservice.api.repository;
 
+import com.vi.tenantservice.api.model.TenantDataView;
 import com.vi.tenantservice.api.model.TenantEntity;
-import com.vi.tenantservice.api.model.TenantEntity.TenantBase;
 import com.vi.tenantservice.api.model.TenantRestrictedDataView;
 import java.util.List;
 import org.springframework.data.domain.Page;
@@ -16,6 +16,91 @@ public interface TenantRepository extends JpaRepository<TenantEntity, Long> {
 
   @Query("SELECT t.id FROM TenantEntity t WHERE t.subdomain = :subdomain")
   Long findIdBySubdomain(@Param("subdomain") String subdomain);
+
+  @Query(
+      value =
+          "SELECT new com.vi.tenantservice.api.model.TenantDataView("
+              + "t.id, "
+              + "t.name, "
+              + "t.subdomain, "
+              + "t.address, "
+              + "t.description, "
+              + "t.licensingAllowedNumberOfUsers, "
+              + "t.themingLogo, "
+              + "t.themingAssociationLogo, "
+              + "t.themingFavicon, "
+              + "t.themingPrimaryColor, "
+              + "t.themingSecondaryColor, "
+              + "t.contentImpressum, "
+              + "t.contentClaim, "
+              + "t.contentPrivacy, "
+              + "t.contentPrivacyActivationDate, "
+              + "t.contentTermsAndConditions, "
+              + "t.contentTermsAndConditionsActivationDate, "
+              + "t.settings, "
+              + "t.createDate, "
+              + "t.updateDate) "
+              + "FROM TenantEntity t WHERE t.id = :id")
+  TenantDataView findTenantDataById(@Param("id") Long id);
+
+  @Query(
+      value =
+          "SELECT new com.vi.tenantservice.api.model.TenantDataView("
+              + "t.id, "
+              + "t.name, "
+              + "t.subdomain, "
+              + "t.address, "
+              + "t.description, "
+              + "t.licensingAllowedNumberOfUsers, "
+              + "t.themingLogo, "
+              + "t.themingAssociationLogo, "
+              + "t.themingFavicon, "
+              + "t.themingPrimaryColor, "
+              + "t.themingSecondaryColor, "
+              + "t.contentImpressum, "
+              + "t.contentClaim, "
+              + "t.contentPrivacy, "
+              + "t.contentPrivacyActivationDate, "
+              + "t.contentTermsAndConditions, "
+              + "t.contentTermsAndConditionsActivationDate, "
+              + "t.settings, "
+              + "t.createDate, "
+              + "t.updateDate) "
+              + "FROM TenantEntity t")
+  List<TenantDataView> findAllTenantData();
+
+  @Query(
+      value =
+          "SELECT new com.vi.tenantservice.api.model.TenantDataView("
+              + "t.id, "
+              + "t.name, "
+              + "t.subdomain, "
+              + "t.address, "
+              + "t.description, "
+              + "t.licensingAllowedNumberOfUsers, "
+              + "t.themingLogo, "
+              + "t.themingAssociationLogo, "
+              + "t.themingFavicon, "
+              + "t.themingPrimaryColor, "
+              + "t.themingSecondaryColor, "
+              + "t.contentImpressum, "
+              + "t.contentClaim, "
+              + "t.contentPrivacy, "
+              + "t.contentPrivacyActivationDate, "
+              + "t.contentTermsAndConditions, "
+              + "t.contentTermsAndConditionsActivationDate, "
+              + "t.settings, "
+              + "t.createDate, "
+              + "t.updateDate) "
+              + "FROM TenantEntity t "
+              + "WHERE"
+              + "  t.id != 0L "
+              + "  AND ( :infix = '*' "
+              + "  OR cast(t.id as string) LIKE CONCAT('%', UPPER(:infix), '%') "
+              + "  OR UPPER(t.name) LIKE CONCAT('%', UPPER(:infix), '%')"
+              + "  )")
+  Page<TenantDataView> findAllTenantDataExceptTechnicalByInfix(
+      @Param("infix") String infix, Pageable pageable);
 
   @Query(
       value =
@@ -58,18 +143,6 @@ public interface TenantRepository extends JpaRepository<TenantEntity, Long> {
               + "t.settings) "
               + "FROM TenantEntity t WHERE t.id = :id")
   TenantRestrictedDataView findRestrictedDataById(@Param("id") Long id);
-
-  @Query(
-      value =
-          "SELECT t.id as id, t.name as name "
-              + "FROM TenantEntity t "
-              + "WHERE"
-              + "  id != 0L "
-              + "  AND ( ?1 = '*' "
-              + "  OR cast(t.id as string) LIKE CONCAT('%', UPPER(?1), '%') "
-              + "  OR UPPER(t.name) LIKE CONCAT('%', UPPER(?1), '%')"
-              + "  )")
-  Page<TenantBase> findAllExceptTechnicalByInfix(String infix, Pageable pageable);
 
   List<TenantEntity> findAllByIdIn(List<Long> tenantIds);
 }

--- a/src/main/java/com/vi/tenantservice/api/repository/TenantRepository.java
+++ b/src/main/java/com/vi/tenantservice/api/repository/TenantRepository.java
@@ -2,6 +2,7 @@ package com.vi.tenantservice.api.repository;
 
 import com.vi.tenantservice.api.model.TenantEntity;
 import com.vi.tenantservice.api.model.TenantEntity.TenantBase;
+import com.vi.tenantservice.api.model.TenantRestrictedDataView;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,6 +16,48 @@ public interface TenantRepository extends JpaRepository<TenantEntity, Long> {
 
   @Query("SELECT t.id FROM TenantEntity t WHERE t.subdomain = :subdomain")
   Long findIdBySubdomain(@Param("subdomain") String subdomain);
+
+  @Query(
+      value =
+          "SELECT new com.vi.tenantservice.api.model.TenantRestrictedDataView("
+              + "t.id, "
+              + "t.name, "
+              + "t.subdomain, "
+              + "t.themingLogo, "
+              + "t.themingAssociationLogo, "
+              + "t.themingFavicon, "
+              + "t.themingPrimaryColor, "
+              + "t.themingSecondaryColor, "
+              + "t.contentImpressum, "
+              + "t.contentClaim, "
+              + "t.contentPrivacy, "
+              + "t.contentPrivacyActivationDate, "
+              + "t.contentTermsAndConditions, "
+              + "t.contentTermsAndConditionsActivationDate, "
+              + "t.settings) "
+              + "FROM TenantEntity t WHERE t.subdomain = :subdomain")
+  TenantRestrictedDataView findRestrictedDataBySubdomain(@Param("subdomain") String subdomain);
+
+  @Query(
+      value =
+          "SELECT new com.vi.tenantservice.api.model.TenantRestrictedDataView("
+              + "t.id, "
+              + "t.name, "
+              + "t.subdomain, "
+              + "t.themingLogo, "
+              + "t.themingAssociationLogo, "
+              + "t.themingFavicon, "
+              + "t.themingPrimaryColor, "
+              + "t.themingSecondaryColor, "
+              + "t.contentImpressum, "
+              + "t.contentClaim, "
+              + "t.contentPrivacy, "
+              + "t.contentPrivacyActivationDate, "
+              + "t.contentTermsAndConditions, "
+              + "t.contentTermsAndConditionsActivationDate, "
+              + "t.settings) "
+              + "FROM TenantEntity t WHERE t.id = :id")
+  TenantRestrictedDataView findRestrictedDataById(@Param("id") Long id);
 
   @Query(
       value =

--- a/src/main/java/com/vi/tenantservice/api/service/SingleDomainTenantOverrideService.java
+++ b/src/main/java/com/vi/tenantservice/api/service/SingleDomainTenantOverrideService.java
@@ -4,7 +4,7 @@ import static com.vi.tenantservice.api.converter.ConverterUtils.nullAsFalse;
 
 import com.vi.tenantservice.api.converter.TenantConverter;
 import com.vi.tenantservice.api.model.RestrictedTenantDTO;
-import com.vi.tenantservice.api.model.TenantEntity;
+import com.vi.tenantservice.api.model.TenantRestrictedData;
 import com.vi.tenantservice.api.service.consultingtype.ApplicationSettingsService;
 import com.vi.tenantservice.applicationsettingsservice.generated.web.model.FeatureToggleDTO;
 import lombok.AllArgsConstructor;
@@ -21,7 +21,7 @@ public class SingleDomainTenantOverrideService {
   private final @NonNull ApplicationSettingsService applicationSettingsService;
 
   public RestrictedTenantDTO overridePrivacyAndCertainSettings(
-      TenantEntity mainTenant, TenantEntity actualTenant) {
+      TenantRestrictedData mainTenant, TenantRestrictedData actualTenant) {
     String lang = translationService.getCurrentLanguageContext();
 
     RestrictedTenantDTO mainTenantRestrictedDTO = getRestrictedTenantDTO(mainTenant, lang);
@@ -52,7 +52,7 @@ public class SingleDomainTenantOverrideService {
             overridingRestrictedTenantDTO.getSettings().getFeatureAttachmentUploadDisabled());
   }
 
-  private RestrictedTenantDTO getRestrictedTenantDTO(TenantEntity mainTenant, String lang) {
+  private RestrictedTenantDTO getRestrictedTenantDTO(TenantRestrictedData mainTenant, String lang) {
     return tenantConverter.toRestrictedTenantDTO(mainTenant, lang);
   }
 

--- a/src/main/java/com/vi/tenantservice/api/service/TenantService.java
+++ b/src/main/java/com/vi/tenantservice/api/service/TenantService.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vi.tenantservice.api.exception.TenantValidationException;
 import com.vi.tenantservice.api.model.TenantEntity;
 import com.vi.tenantservice.api.model.TenantEntity.TenantBase;
+import com.vi.tenantservice.api.model.TenantRestrictedData;
 import com.vi.tenantservice.api.model.TenantSettings;
 import com.vi.tenantservice.api.repository.TenantRepository;
 import com.vi.tenantservice.api.service.consultingtype.ApplicationSettingsService;
@@ -126,6 +127,14 @@ public class TenantService {
 
   public Optional<Long> findTenantIdBySubdomain(String subdomain) {
     return Optional.ofNullable(tenantRepository.findIdBySubdomain(subdomain));
+  }
+
+  public Optional<TenantRestrictedData> findRestrictedTenantDataBySubdomain(String subdomain) {
+    return Optional.ofNullable(tenantRepository.findRestrictedDataBySubdomain(subdomain));
+  }
+
+  public Optional<TenantRestrictedData> findRestrictedTenantDataById(Long id) {
+    return Optional.ofNullable(tenantRepository.findRestrictedDataById(id));
   }
 
   public List<TenantEntity> getAllTenants() {

--- a/src/main/java/com/vi/tenantservice/api/service/TenantService.java
+++ b/src/main/java/com/vi/tenantservice/api/service/TenantService.java
@@ -4,8 +4,8 @@ import static com.vi.tenantservice.api.exception.httpresponse.HttpStatusExceptio
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vi.tenantservice.api.exception.TenantValidationException;
+import com.vi.tenantservice.api.model.TenantData;
 import com.vi.tenantservice.api.model.TenantEntity;
-import com.vi.tenantservice.api.model.TenantEntity.TenantBase;
 import com.vi.tenantservice.api.model.TenantRestrictedData;
 import com.vi.tenantservice.api.model.TenantSettings;
 import com.vi.tenantservice.api.repository.TenantRepository;
@@ -76,15 +76,15 @@ public class TenantService {
   }
 
   private void validateTenantSubdomainDoesNotExist(TenantEntity tenantEntity) {
-    var dbTenant = tenantRepository.findBySubdomain(tenantEntity.getSubdomain());
-    if (tenantWithSuchSubdomainAlreadyExists(tenantEntity, dbTenant)) {
+    var existingTenantId = tenantRepository.findIdBySubdomain(tenantEntity.getSubdomain());
+    if (tenantWithSuchSubdomainAlreadyExists(tenantEntity, existingTenantId)) {
       throw new TenantValidationException(SUBDOMAIN_NOT_UNIQUE);
     }
   }
 
   private boolean tenantWithSuchSubdomainAlreadyExists(
-      TenantEntity tenantEntity, TenantEntity dbTenant) {
-    return dbTenant != null && !dbTenant.getId().equals(tenantEntity.getId());
+      TenantEntity tenantEntity, Long existingTenantId) {
+    return existingTenantId != null && !existingTenantId.equals(tenantEntity.getId());
   }
 
   public TenantEntity update(TenantEntity tenantEntity) {
@@ -120,6 +120,10 @@ public class TenantService {
     return tenantRepository.findById(id);
   }
 
+  public Optional<TenantData> findTenantDataById(Long id) {
+    return Optional.ofNullable(tenantRepository.findTenantDataById(id));
+  }
+
   public Optional<TenantEntity> findTenantBySubdomain(String subdomain) {
     var bySubdomain = tenantRepository.findBySubdomain(subdomain);
     return bySubdomain != null ? Optional.of(bySubdomain) : Optional.empty();
@@ -141,8 +145,15 @@ public class TenantService {
     return tenantRepository.findAll();
   }
 
-  public Page<TenantBase> findAllExceptTechnicalByInfix(String infix, PageRequest pageRequest) {
-    return tenantRepository.findAllExceptTechnicalByInfix(infix, pageRequest);
+  public List<TenantData> getAllTenantData() {
+    return List.copyOf(tenantRepository.findAllTenantData());
+  }
+
+  public Page<TenantData> findAllTenantDataExceptTechnicalByInfix(
+      String infix, PageRequest pageRequest) {
+    return tenantRepository
+        .findAllTenantDataExceptTechnicalByInfix(infix, pageRequest)
+        .map(tenantData -> tenantData);
   }
 
   public List<TenantEntity> findAllByIds(List<Long> tenantIds) {

--- a/src/main/java/com/vi/tenantservice/api/tenant/SubdomainTenantResolver.java
+++ b/src/main/java/com/vi/tenantservice/api/tenant/SubdomainTenantResolver.java
@@ -25,9 +25,9 @@ public class SubdomainTenantResolver implements TenantResolver {
   private Optional<Long> resolveTenantFromSubdomain() {
     Optional<String> currentSubdomain = subdomainExtractor.getCurrentSubdomain();
     if (currentSubdomain.isPresent()) {
-      var tenant = tenantRepository.findBySubdomain(currentSubdomain.get());
-      if (tenant != null) {
-        return of(tenant.getId());
+      var tenantId = tenantRepository.findIdBySubdomain(currentSubdomain.get());
+      if (tenantId != null) {
+        return of(tenantId);
       }
     }
     return Optional.empty();

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -21,10 +21,9 @@ spring.datasource.url=${SPRING_DATASOURCE_URL:}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME:}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:}
 
-# Liquibase — enabled in dev so new environments bootstrap from changesets automatically.
-# Prod stays false — schemas managed via ORISO-Database repo (platform-wide decision).
+# Liquibase
 spring.liquibase.enabled=true
-# Database already exists, skip Liquibase migration
+spring.liquibase.change-log=classpath:db/changelog/tenantservice-prod-master.xml
 
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -22,8 +22,9 @@ spring.datasource.username=${SPRING_DATASOURCE_USERNAME:}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:}
 
 # Liquibase
-spring.liquibase.enabled=false
-# Database already exists, skip Liquibase migration
+spring.liquibase.enabled=${SPRING_LIQUIBASE_ENABLED:true}
+spring.liquibase.change-log=classpath:db/changelog/tenantservice-prod-master.xml
+spring.jpa.hibernate.ddl-auto=${SPRING_JPA_HIBERNATE_DDL_AUTO:validate}
 
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.format_sql=false

--- a/src/main/resources/application-staging.properties
+++ b/src/main/resources/application-staging.properties
@@ -23,8 +23,9 @@ spring.datasource.username=${SPRING_DATASOURCE_USERNAME:}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:}
 
 # Liquibase
-spring.liquibase.enabled=false
-# Database already exists, skip Liquibase migration
+spring.liquibase.enabled=${SPRING_LIQUIBASE_ENABLED:true}
+spring.liquibase.change-log=classpath:db/changelog/tenantservice-prod-master.xml
+spring.jpa.hibernate.ddl-auto=${SPRING_JPA_HIBERNATE_DDL_AUTO:validate}
 
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true

--- a/src/test/java/com/vi/tenantservice/api/facade/TenantServiceFacadeTest.java
+++ b/src/test/java/com/vi/tenantservice/api/facade/TenantServiceFacadeTest.java
@@ -515,6 +515,25 @@ class TenantServiceFacadeTest {
   }
 
   @Test
+  void findTenantBySubdomain_Should_ReturnEmpty_When_MainTenantIsNotFoundInSingleDomainMode() {
+    // given
+    ReflectionTestUtils.setField(tenantServiceFacade, "multitenancyWithSingleDomain", true);
+
+    when(tenantService.findRestrictedTenantDataBySubdomain(SINGLE_DOMAIN_SUBDOMAIN_NAME))
+        .thenReturn(Optional.empty());
+    when(tenantResolverService.tryResolveForNonAuthUsers()).thenReturn(Optional.of(2L));
+
+    // when
+    Optional<RestrictedTenantDTO> tenantDTO =
+        tenantServiceFacade.findTenantBySubdomain(SINGLE_DOMAIN_SUBDOMAIN_NAME, null);
+
+    // then
+    assertThat(tenantDTO).isEmpty();
+    verify(tenantService, never()).findRestrictedTenantDataById(2L);
+    verifyNoInteractions(singleDomainTenantOverrideService);
+  }
+
+  @Test
   void canAccessTenant_Should_useTenantIdLookupInsteadOfLoadingTenantEntity() {
     // given
     when(subdomainExtractor.getCurrentSubdomain()).thenReturn(Optional.of("localhost"));

--- a/src/test/java/com/vi/tenantservice/api/facade/TenantServiceFacadeTest.java
+++ b/src/test/java/com/vi/tenantservice/api/facade/TenantServiceFacadeTest.java
@@ -149,7 +149,7 @@ class TenantServiceFacadeTest {
     when(converter.toEntity(tenantMultilingualDTO)).thenReturn(entity);
     when(tenantService.create(entity)).thenReturn(entity);
     ReflectionTestUtils.setField(tenantServiceFacade, "multitenancyWithSingleDomain", true);
-    when(tenantService.getAllTenants()).thenReturn(List.of(technicalTenant));
+    when(tenantService.getAllTenantData()).thenReturn(List.of(technicalTenant));
     when(subdomainExtractor.getCurrentSubdomain()).thenReturn(Optional.of("app1"));
 
     // when
@@ -177,7 +177,7 @@ class TenantServiceFacadeTest {
     when(converter.toEntity(tenantMultilingualDTO)).thenReturn(entity);
     when(tenantService.create(entity)).thenReturn(entity);
     ReflectionTestUtils.setField(tenantServiceFacade, "multitenancyWithSingleDomain", true);
-    when(tenantService.getAllTenants()).thenReturn(List.of(technicalTenant));
+    when(tenantService.getAllTenantData()).thenReturn(List.of(technicalTenant));
     when(subdomainExtractor.getCurrentSubdomain()).thenReturn(Optional.of("app2"));
 
     // when
@@ -411,7 +411,7 @@ class TenantServiceFacadeTest {
   @Test
   void findTenantById_Should_findTenant_When_ExistingIdIsPassedForSingleTenantAdmin() {
     // given
-    when(tenantService.findTenantById(ID)).thenReturn(Optional.of(tenantEntity));
+    when(tenantService.findTenantDataById(ID)).thenReturn(Optional.of(tenantEntity));
     when(translationService.getCurrentLanguageContext()).thenReturn("de");
     when(converter.toDTO(tenantEntity, "de")).thenReturn(tenantDTO);
     // when
@@ -422,7 +422,7 @@ class TenantServiceFacadeTest {
   @Test
   void findMultilingualTenantById_Should_findTenant_When_ExistingIdIsPassedForSingleTenantAdmin() {
     // given
-    when(tenantService.findTenantById(ID)).thenReturn(Optional.of(tenantEntity));
+    when(tenantService.findTenantDataById(ID)).thenReturn(Optional.of(tenantEntity));
     tenantEntity.setId(1L);
     tenantMultilingualDTO.setId(1L);
     when(consultingTypeService.getConsultingTypesByTenantId(Mockito.anyInt()))
@@ -444,13 +444,13 @@ class TenantServiceFacadeTest {
     // when
     tenantServiceFacade.getAllTenants();
     // then
-    verify(tenantService).getAllTenants();
+    verify(tenantService).getAllTenantData();
   }
 
   @Test
   void getSingleTenant_Should_findTenant_When_onlyOneTenantIsPresent() {
     // given
-    when(tenantService.getAllTenants()).thenReturn(List.of(tenantEntity));
+    when(tenantService.getAllTenantData()).thenReturn(List.of(tenantEntity));
     when(translationService.getCurrentLanguageContext()).thenReturn(DE);
     when(converter.toRestrictedTenantDTO(tenantEntity, DE)).thenReturn(restrictedTenantDTO);
 
@@ -458,7 +458,7 @@ class TenantServiceFacadeTest {
     tenantServiceFacade.getSingleTenant();
 
     // then
-    verify(tenantService).getAllTenants();
+    verify(tenantService).getAllTenantData();
     verify(converter).toRestrictedTenantDTO(tenantEntity, DE);
   }
 
@@ -467,7 +467,7 @@ class TenantServiceFacadeTest {
     // given
     TenantEntity secondTenantEntity = new TenantEntity();
     secondTenantEntity.setId(2L);
-    when(tenantService.getAllTenants()).thenReturn(List.of(tenantEntity, secondTenantEntity));
+    when(tenantService.getAllTenantData()).thenReturn(List.of(tenantEntity, secondTenantEntity));
 
     // then
     assertThrows(
@@ -477,7 +477,7 @@ class TenantServiceFacadeTest {
           tenantServiceFacade.getSingleTenant();
         });
 
-    verify(tenantService).getAllTenants();
+    verify(tenantService).getAllTenantData();
     verifyNoInteractions(converter);
   }
 

--- a/src/test/java/com/vi/tenantservice/api/facade/TenantServiceFacadeTest.java
+++ b/src/test/java/com/vi/tenantservice/api/facade/TenantServiceFacadeTest.java
@@ -25,6 +25,7 @@ import com.vi.tenantservice.api.model.RestrictedTenantDTO;
 import com.vi.tenantservice.api.model.Settings;
 import com.vi.tenantservice.api.model.TenantDTO;
 import com.vi.tenantservice.api.model.TenantEntity;
+import com.vi.tenantservice.api.model.TenantRestrictedData;
 import com.vi.tenantservice.api.service.SingleDomainTenantOverrideService;
 import com.vi.tenantservice.api.service.TemplateRenderer;
 import com.vi.tenantservice.api.service.TemplateService;
@@ -491,13 +492,14 @@ class TenantServiceFacadeTest {
         "tenantConverter",
         new TenantConverter(new TemplateService(), templateRenderer));
 
-    Optional<TenantEntity> defaultTenant = getTenantWithPrivacy("{\"de\":\"content1\"}");
-    Optional<TenantEntity> accessTokenTenantData = getTenantWithPrivacy("{\"de\":\"content2\"}");
+    Optional<TenantRestrictedData> defaultTenant = getTenantWithPrivacy("{\"de\":\"content1\"}");
+    Optional<TenantRestrictedData> accessTokenTenantData =
+        getTenantWithPrivacy("{\"de\":\"content2\"}");
 
-    when(tenantService.findTenantBySubdomain(SINGLE_DOMAIN_SUBDOMAIN_NAME))
+    when(tenantService.findRestrictedTenantDataBySubdomain(SINGLE_DOMAIN_SUBDOMAIN_NAME))
         .thenReturn(defaultTenant);
     when(tenantResolverService.tryResolveForNonAuthUsers()).thenReturn(Optional.of(2L));
-    when(tenantService.findTenantById(2L)).thenReturn(accessTokenTenantData);
+    when(tenantService.findRestrictedTenantDataById(2L)).thenReturn(accessTokenTenantData);
 
     RestrictedTenantDTO overriddenDTO =
         new RestrictedTenantDTO().content(new Content().privacy("content2"));
@@ -528,10 +530,10 @@ class TenantServiceFacadeTest {
     verify(tenantService, never()).findTenantBySubdomain("localhost");
   }
 
-  private static Optional<TenantEntity> getTenantWithPrivacy(String contentPrivacy) {
+  private static Optional<TenantRestrictedData> getTenantWithPrivacy(String contentPrivacy) {
     TenantEntity defaultTenantEntity = new TenantEntity();
     defaultTenantEntity.setContentPrivacy(contentPrivacy);
-    Optional<TenantEntity> defaultTenant = Optional.of(defaultTenantEntity);
+    Optional<TenantRestrictedData> defaultTenant = Optional.of(defaultTenantEntity);
     return defaultTenant;
   }
 }

--- a/src/test/java/com/vi/tenantservice/api/repository/TenantRepositoryTest.java
+++ b/src/test/java/com/vi/tenantservice/api/repository/TenantRepositoryTest.java
@@ -104,4 +104,26 @@ class TenantRepositoryTest {
     // then
     assertNotNull(tenant);
   }
+
+  @Test
+  void findTenantDataById_Should_NotRequireDpaColumnsInProjection() {
+    // when
+    var tenant = tenantRepository.findTenantDataById(EXISTING_ID);
+
+    // then
+    assertNotNull(tenant);
+    assertThat(tenant.getId()).isEqualTo(EXISTING_ID);
+    assertThat(tenant.getName()).isEqualTo("Happylife Gmbh");
+    assertThat(tenant.getSubdomain()).isEqualTo("happylife");
+  }
+
+  @Test
+  void findAllTenantData_Should_NotRequireDpaColumnsInProjection() {
+    // when
+    var tenants = tenantRepository.findAllTenantData();
+
+    // then
+    assertThat(tenants.size()).isEqualTo(1);
+    assertThat(tenants.get(0).getId()).isEqualTo(EXISTING_ID);
+  }
 }

--- a/src/test/java/com/vi/tenantservice/api/service/TenantServiceTest.java
+++ b/src/test/java/com/vi/tenantservice/api/service/TenantServiceTest.java
@@ -43,11 +43,12 @@ class TenantServiceTest {
   void create_Should_CreateTenantAndSetCreationDate() {
     // given
     TenantEntity tenantEntity = new TenantEntity();
+    when(tenantRepository.findIdBySubdomain(tenantEntity.getSubdomain())).thenReturn(null);
     // when
     tenantService.create(tenantEntity);
     // then
     verify(tenantRepository).save(tenantEntity);
-    verify(tenantRepository).findBySubdomain(tenantEntity.getSubdomain());
+    verify(tenantRepository).findIdBySubdomain(tenantEntity.getSubdomain());
     assertThat(tenantEntity.getCreateDate()).isNotNull();
     assertThat(tenantEntity.getUpdateDate()).isNotNull();
   }
@@ -76,7 +77,7 @@ class TenantServiceTest {
     TenantEntity tenantEntity = new TenantEntity();
     givenApplicationSettingsWithMainTenantSubdomain(MAIN_SUBDOMAIN_FOR_SINGLE_DOMAIN_MULTITENANCY);
     tenantEntity.setSubdomain(MAIN_SUBDOMAIN_FOR_SINGLE_DOMAIN_MULTITENANCY);
-    when(tenantRepository.findBySubdomain(MAIN_SUBDOMAIN_FOR_SINGLE_DOMAIN_MULTITENANCY))
+    when(tenantRepository.findIdBySubdomain(MAIN_SUBDOMAIN_FOR_SINGLE_DOMAIN_MULTITENANCY))
         .thenReturn(null);
     // when
     tenantService.create(tenantEntity);
@@ -99,8 +100,8 @@ class TenantServiceTest {
     tenantEntity.setSubdomain(MAIN_SUBDOMAIN_FOR_SINGLE_DOMAIN_MULTITENANCY);
     TenantEntity existingTenant = new TenantEntity();
     existingTenant.setId(1L);
-    when(tenantRepository.findBySubdomain(MAIN_SUBDOMAIN_FOR_SINGLE_DOMAIN_MULTITENANCY))
-        .thenReturn(existingTenant);
+    when(tenantRepository.findIdBySubdomain(MAIN_SUBDOMAIN_FOR_SINGLE_DOMAIN_MULTITENANCY))
+        .thenReturn(existingTenant.getId());
 
     // then
     assertThrows(
@@ -117,13 +118,14 @@ class TenantServiceTest {
     EasyRandom random = new EasyRandom();
     TenantEntity tenantEntity = random.nextObject(TenantEntity.class);
     LocalDateTime previousUpdateDate = tenantEntity.getUpdateDate();
+    when(tenantRepository.findIdBySubdomain(tenantEntity.getSubdomain())).thenReturn(null);
 
     // when
     tenantService.update(tenantEntity);
 
     // then
     verify(tenantRepository).save(tenantEntity);
-    verify(tenantRepository).findBySubdomain(tenantEntity.getSubdomain());
+    verify(tenantRepository).findIdBySubdomain(tenantEntity.getSubdomain());
     assertThat(tenantEntity.getUpdateDate()).isNotNull();
     assertThat(tenantEntity.getUpdateDate()).isNotEqualTo(previousUpdateDate);
   }
@@ -161,8 +163,8 @@ class TenantServiceTest {
 
     TenantEntity existingTenant = new TenantEntity();
     existingTenant.setId(1L);
-    when(tenantRepository.findBySubdomain(MAIN_SUBDOMAIN_FOR_SINGLE_DOMAIN_MULTITENANCY))
-        .thenReturn(existingTenant);
+    when(tenantRepository.findIdBySubdomain(MAIN_SUBDOMAIN_FOR_SINGLE_DOMAIN_MULTITENANCY))
+        .thenReturn(existingTenant.getId());
 
     // then
     assertThrows(
@@ -192,7 +194,7 @@ class TenantServiceTest {
 
     verify(tenantRepository).findAllByIdIn(java.util.List.of(2L));
     verify(tenantRepository).saveAll(java.util.List.of(tenantEntity));
-    verify(tenantRepository, never()).findBySubdomain(org.mockito.ArgumentMatchers.any());
+    verify(tenantRepository, never()).findIdBySubdomain(org.mockito.ArgumentMatchers.any());
     assertThat(tenantEntity.getSettings()).isEqualTo("{\"tenantAdminControls\":{}}");
     assertThat(tenantEntity.getUpdateDate()).isNotNull();
   }
@@ -220,5 +222,13 @@ class TenantServiceTest {
     tenantService.getAllTenants();
     // then
     verify(tenantRepository).findAll();
+  }
+
+  @Test
+  void getAllTenantData_Should_CallProjectionQuery() {
+    // when
+    tenantService.getAllTenantData();
+    // then
+    verify(tenantRepository).findAllTenantData();
   }
 }

--- a/src/test/java/com/vi/tenantservice/api/tenant/SubdomainTenantResolverTest.java
+++ b/src/test/java/com/vi/tenantservice/api/tenant/SubdomainTenantResolverTest.java
@@ -3,7 +3,6 @@ package com.vi.tenantservice.api.tenant;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-import com.vi.tenantservice.api.model.TenantEntity;
 import com.vi.tenantservice.api.repository.TenantRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Optional;
@@ -28,9 +27,7 @@ class SubdomainTenantResolverTest {
   void resolve_should_resolveTenantId_When_SubdomainCouldBeDetermined() {
     // given
     when(subdomainExtractor.getCurrentSubdomain()).thenReturn(Optional.of("mucoviscidose"));
-    TenantEntity tenantEntity = new TenantEntity();
-    tenantEntity.setId(1L);
-    when(tenantRepository.findBySubdomain("mucoviscidose")).thenReturn(tenantEntity);
+    when(tenantRepository.findIdBySubdomain("mucoviscidose")).thenReturn(1L);
 
     // when
     Optional<Long> resolve = subdomainTenantResolver.resolve(httpServletRequest);

--- a/src/test/java/com/vi/tenantservice/config/DeploymentSchemaConfigurationTest.java
+++ b/src/test/java/com/vi/tenantservice/config/DeploymentSchemaConfigurationTest.java
@@ -1,0 +1,44 @@
+package com.vi.tenantservice.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+class DeploymentSchemaConfigurationTest {
+
+  @Test
+  void prodProfile_Should_RunLiquibaseAndValidateHibernateSchema() throws IOException {
+    var properties = loadProperties("application-prod.properties");
+
+    assertThat(properties.getProperty("spring.liquibase.enabled"))
+        .isEqualTo("${SPRING_LIQUIBASE_ENABLED:true}");
+    assertThat(properties.getProperty("spring.liquibase.change-log"))
+        .isEqualTo("classpath:db/changelog/tenantservice-prod-master.xml");
+    assertThat(properties.getProperty("spring.jpa.hibernate.ddl-auto"))
+        .isEqualTo("${SPRING_JPA_HIBERNATE_DDL_AUTO:validate}");
+  }
+
+  @Test
+  void stagingProfile_Should_RunLiquibaseAndValidateHibernateSchema() throws IOException {
+    var properties = loadProperties("application-staging.properties");
+
+    assertThat(properties.getProperty("spring.liquibase.enabled"))
+        .isEqualTo("${SPRING_LIQUIBASE_ENABLED:true}");
+    assertThat(properties.getProperty("spring.liquibase.change-log"))
+        .isEqualTo("classpath:db/changelog/tenantservice-prod-master.xml");
+    assertThat(properties.getProperty("spring.jpa.hibernate.ddl-auto"))
+        .isEqualTo("${SPRING_JPA_HIBERNATE_DDL_AUTO:validate}");
+  }
+
+  private Properties loadProperties(String fileName) throws IOException {
+    var properties = new Properties();
+    try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(fileName)) {
+      assertThat(inputStream).as(fileName + " exists").isNotNull();
+      properties.load(inputStream);
+    }
+    return properties;
+  }
+}


### PR DESCRIPTION
## Summary
- Route public/restricted tenant reads through a small TenantRestrictedData projection instead of loading the full TenantEntity
- Avoid selecting content_dpa and dpa_activation_date for /tenant/public/{subdomain}, /tenant/public/id/{tenantId}, and tenant-context public reads
- Keep full admin tenant reads unchanged and add projection-compatible conversion/override support

## Verification
- ./mvnw '-Dtest=TenantConverterTest,TenantServiceFacadeTest,TenantControllerIT#getRestrictedTenantData*' test
- ./mvnw spotless:apply test

The focused controller test SQL now selects only public tenant columns and does not include content_dpa or dpa_activation_date.