### PR TITLE
fix: add spring-boot-liquibase module so boot-time migrations run again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,13 @@
             <version>${liquibase-core.version}</version>
         </dependency>
 
+        <!-- Spring Boot 4 moved LiquibaseAutoConfiguration into its own module;
+             without this, spring.liquibase.* is silently ignored at boot. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-liquibase</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>


### PR DESCRIPTION
## What breaks without this

Since the Spring Boot 4 upgrade, turning Liquibase on does nothing. Spring Boot 4 moved `LiquibaseAutoConfiguration` out of `spring-boot-autoconfigure` into the separate `spring-boot-liquibase` module. TenantService only depends on `liquibase-core`, so `spring.liquibase.enabled=true` is silently a no-op — no migrations run at startup and nothing warns about it.

## Fix

Add the `spring-boot-liquibase` dependency (version managed by the Spring Boot parent, resolves to 4.0.1). One pom.xml change, nothing else.

## How it was found

Full-platform bootstrap from empty databases on the local fast-track stack (2026-07-04): TenantService booted against an empty schema without running a single changeset. With this dependency added, the full chain (19/19 changesets) runs at boot and bootstraps the schema from scratch.

## Validation

- `./mvnw -B compile` green (JDK 21)
- `mvn dependency:tree` now shows `org.springframework.boot:spring-boot-liquibase:jar:4.0.1:compile`
- Boot-level: on the fast-track stack the same change made the TenantService Liquibase chain execute 19/19 changesets against a fresh MariaDB 10.11
- `spotless:apply` run before push

Sibling fixes: same change for AgencyService, and OpenResilienceInitiative/ORISO-AgencyService#91 for related migration hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)