### PR TITLE
Fix three DPA/legal-content bugs found by the Playwright click gate

### DIFF
--- a/api/tenantservice.yaml
+++ b/api/tenantservice.yaml
@@ -827,6 +827,17 @@ components:
         impressum:
           type: string
           example: "Llorem ipsum..."
+        impressumLanguages:
+          type: object
+          additionalProperties:
+            type: string
+          description: >-
+            Raw stored language map for the impressum, including the `<lang>__meta`
+            machine-translation metadata keys (JSON strings like
+            `{"mt":true,"src":"de","at":"<ISO>"}`). Lets clients show a
+            "machine translated / legally binding is German" notice. The `<lang>`
+            values are the same sanitized HTML the resolved `impressum` field is
+            picked from; the map is exposed as stored, no additional processing.
         claim:
           type: string
           example: "Llorem ipsum..."
@@ -834,6 +845,16 @@ components:
         privacy:
           type: string
           example: "Llorem ipsum..."
+        privacyLanguages:
+          type: object
+          additionalProperties:
+            type: string
+          description: >-
+            Raw stored language map for the privacy statement, including the
+            `<lang>__meta` machine-translation metadata keys. Same semantics as
+            `impressumLanguages`. Note: contains the stored (unrendered) privacy
+            text, i.e. without the data-protection placeholder rendering applied
+            to `renderedPrivacy`.
         renderedPrivacy:
           type: string
           example: "Llorem ipsum..."

--- a/src/main/java/com/vi/tenantservice/api/converter/TenantConverter.java
+++ b/src/main/java/com/vi/tenantservice/api/converter/TenantConverter.java
@@ -500,6 +500,11 @@ public class TenantConverter {
     DataProtectionContactTemplateDTO dataProtectionContactTemplate =
         getDataProtectionContactTemplate(lang);
     return new Content(getTranslatedStringFromMap(tenant.getContentImpressum(), lang))
+        // Raw stored language maps (incl. the <lang>__meta machine-translation metadata keys)
+        // alongside the resolved strings, so public clients can show a "machine translated"
+        // notice. Kept lean on purpose: only for the legal contents impressum and privacy.
+        .impressumLanguages(convertMapFromJson(tenant.getContentImpressum()))
+        .privacyLanguages(convertMapFromJson(tenant.getContentPrivacy()))
         .claim(getTranslatedStringFromMap(tenant.getContentClaim(), lang))
         .privacy(privacyPotentiallyWithPlaceholders)
         .termsAndConditions(getTranslatedStringFromMap(tenant.getContentTermsAndConditions(), lang))

--- a/src/main/java/com/vi/tenantservice/api/service/SingleDomainTenantOverrideService.java
+++ b/src/main/java/com/vi/tenantservice/api/service/SingleDomainTenantOverrideService.java
@@ -63,6 +63,8 @@ public class SingleDomainTenantOverrideService {
           .getContent()
           .dataPrivacyConfirmation(
               overridingRestrictedTenantDTO.getContent().getDataPrivacyConfirmation())
+          // keep the raw language map (incl. __meta keys) consistent with the overridden privacy
+          .privacyLanguages(overridingRestrictedTenantDTO.getContent().getPrivacyLanguages())
           .setPrivacy(overridingRestrictedTenantDTO.getContent().getPrivacy());
     }
   }

--- a/src/main/java/com/vi/tenantservice/api/validation/InputSanitizer.java
+++ b/src/main/java/com/vi/tenantservice/api/validation/InputSanitizer.java
@@ -1,10 +1,22 @@
 package com.vi.tenantservice.api.validation;
 
+import java.util.regex.Pattern;
 import org.owasp.html.HtmlPolicyBuilder;
 import org.springframework.stereotype.Component;
 
 @Component
 public class InputSanitizer {
+
+  private static final String[] HEADING_ELEMENTS = {"h1", "h2", "h3", "h4", "h5", "h6"};
+
+  /**
+   * Anchor ids on headings power the legal-content anchor navigation. Restricted to a slug charset
+   * (no colons, quotes, spaces, ...) so the attribute cannot be abused as an XSS vector.
+   */
+  private static final Pattern SAFE_ANCHOR_ID = Pattern.compile("[a-zA-Z0-9\\-_]+");
+
+  /** Marker the admin editor sets on headings whose anchor was explicitly removed. */
+  private static final Pattern ANCHOR_REMOVED_TRUE = Pattern.compile("true");
 
   public String sanitize(String input) {
     var sanitizer = new HtmlPolicyBuilder().toFactory();
@@ -34,6 +46,12 @@ public class InputSanitizer {
             .allowElements("img")
             .allowAttributes("src", "width", "height")
             .onElements("img")
+            .allowAttributes("id")
+            .matching(SAFE_ANCHOR_ID)
+            .onElements(HEADING_ELEMENTS)
+            .allowAttributes("data-anchor-removed")
+            .matching(ANCHOR_REMOVED_TRUE)
+            .onElements(HEADING_ELEMENTS)
             .toFactory();
     return sanitizer.sanitize(input);
   }

--- a/src/main/resources/db/changelog/changeset/0020_fix_dpa_sequence_name_case/0020-changeSet.xml
+++ b/src/main/resources/db/changelog/changeset/0020_fix_dpa_sequence_name_case/0020-changeSet.xml
@@ -1,0 +1,47 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+
+    <!--
+      Changesets 0016/0018 created the DPA sequences with UPPERCASE names
+      (SEQUENCE_TENANT_DPA_SIGNATURE / SEQUENCE_TENANT_DPA_VERSION), but Hibernate's
+      physical naming strategy lowercases sequence names at runtime. On case-sensitive
+      Linux MariaDB (lower_case_table_names=0) every DPA publish/signature insert then
+      fails with "Unknown SEQUENCE: 'sequence_tenant_dpa_version'".
+
+      This changelog renames the uppercase sequences to lowercase (sequences are renamed
+      via RENAME TABLE in MariaDB) and, as a fallback for databases that have neither
+      casing, creates the lowercase sequences. Databases that already have BOTH casings
+      (e.g. manually repaired environments) are left untouched: the rename is skipped and
+      the stray uppercase sequence stays behind, which is harmless.
+
+      Rollbacks are intentionally empty: renaming back to uppercase would re-break the
+      runtime lookup, because the application has always requested the lowercase name.
+    -->
+
+    <changeSet author="oriso" id="renameDpaSignatureSequenceToLowercase">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <sqlCheck expectedResult="1">SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA = 'tenantservice' AND TABLE_TYPE = 'SEQUENCE' AND CAST(TABLE_NAME AS BINARY) = CAST('SEQUENCE_TENANT_DPA_SIGNATURE' AS BINARY)</sqlCheck>
+                <sqlCheck expectedResult="0">SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA = 'tenantservice' AND TABLE_TYPE = 'SEQUENCE' AND CAST(TABLE_NAME AS BINARY) = CAST('sequence_tenant_dpa_signature' AS BINARY)</sqlCheck>
+            </and>
+        </preConditions>
+        <sqlFile path="db/changelog/changeset/0020_fix_dpa_sequence_name_case/renameDpaSignatureSequenceToLowercase.sql" stripComments="true" />
+        <rollback/>
+    </changeSet>
+
+    <changeSet author="oriso" id="renameDpaVersionSequenceToLowercase">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <sqlCheck expectedResult="1">SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA = 'tenantservice' AND TABLE_TYPE = 'SEQUENCE' AND CAST(TABLE_NAME AS BINARY) = CAST('SEQUENCE_TENANT_DPA_VERSION' AS BINARY)</sqlCheck>
+                <sqlCheck expectedResult="0">SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA = 'tenantservice' AND TABLE_TYPE = 'SEQUENCE' AND CAST(TABLE_NAME AS BINARY) = CAST('sequence_tenant_dpa_version' AS BINARY)</sqlCheck>
+            </and>
+        </preConditions>
+        <sqlFile path="db/changelog/changeset/0020_fix_dpa_sequence_name_case/renameDpaVersionSequenceToLowercase.sql" stripComments="true" />
+        <rollback/>
+    </changeSet>
+
+    <changeSet author="oriso" id="createLowercaseDpaSequencesIfMissing">
+        <sqlFile path="db/changelog/changeset/0020_fix_dpa_sequence_name_case/createLowercaseDpaSequencesIfMissing.sql" stripComments="true" />
+        <rollback/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changeset/0020_fix_dpa_sequence_name_case/createLowercaseDpaSequencesIfMissing.sql
+++ b/src/main/resources/db/changelog/changeset/0020_fix_dpa_sequence_name_case/createLowercaseDpaSequencesIfMissing.sql
@@ -1,0 +1,2 @@
+CREATE SEQUENCE IF NOT EXISTS `tenantservice`.`sequence_tenant_dpa_signature` START WITH 100000 INCREMENT BY 1;
+CREATE SEQUENCE IF NOT EXISTS `tenantservice`.`sequence_tenant_dpa_version` START WITH 100000 INCREMENT BY 1;

--- a/src/main/resources/db/changelog/changeset/0020_fix_dpa_sequence_name_case/renameDpaSignatureSequenceToLowercase.sql
+++ b/src/main/resources/db/changelog/changeset/0020_fix_dpa_sequence_name_case/renameDpaSignatureSequenceToLowercase.sql
@@ -1,0 +1,1 @@
+RENAME TABLE `tenantservice`.`SEQUENCE_TENANT_DPA_SIGNATURE` TO `tenantservice`.`sequence_tenant_dpa_signature`;

--- a/src/main/resources/db/changelog/changeset/0020_fix_dpa_sequence_name_case/renameDpaVersionSequenceToLowercase.sql
+++ b/src/main/resources/db/changelog/changeset/0020_fix_dpa_sequence_name_case/renameDpaVersionSequenceToLowercase.sql
@@ -1,0 +1,1 @@
+RENAME TABLE `tenantservice`.`SEQUENCE_TENANT_DPA_VERSION` TO `tenantservice`.`sequence_tenant_dpa_version`;

--- a/src/main/resources/db/changelog/tenantservice-dev-master.xml
+++ b/src/main/resources/db/changelog/tenantservice-dev-master.xml
@@ -26,4 +26,5 @@
   <include file="db/changelog/changeset/0017_tenant_dpa_signature_token/0017-changeSet.xml"/>
   <include file="db/changelog/changeset/0018_tenant_dpa_version/0018-changeSet.xml"/>
   <include file="db/changelog/changeset/0019_tenant_dpa_signature_audit_fields/0019-changeSet.xml"/>
+  <include file="db/changelog/changeset/0020_fix_dpa_sequence_name_case/0020-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenantservice-local-master.xml
+++ b/src/main/resources/db/changelog/tenantservice-local-master.xml
@@ -26,4 +26,5 @@
 	<include file="db/changelog/changeset/0017_tenant_dpa_signature_token/0017-changeSet.xml"/>
 	<include file="db/changelog/changeset/0018_tenant_dpa_version/0018-changeSet.xml"/>
 	<include file="db/changelog/changeset/0019_tenant_dpa_signature_audit_fields/0019-changeSet.xml"/>
+	<include file="db/changelog/changeset/0020_fix_dpa_sequence_name_case/0020-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenantservice-prod-master.xml
+++ b/src/main/resources/db/changelog/tenantservice-prod-master.xml
@@ -23,4 +23,5 @@
   <include file="db/changelog/changeset/0017_tenant_dpa_signature_token/0017-changeSet.xml"/>
   <include file="db/changelog/changeset/0018_tenant_dpa_version/0018-changeSet.xml"/>
   <include file="db/changelog/changeset/0019_tenant_dpa_signature_audit_fields/0019-changeSet.xml"/>
+  <include file="db/changelog/changeset/0020_fix_dpa_sequence_name_case/0020-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/tenantservice-staging-master.xml
+++ b/src/main/resources/db/changelog/tenantservice-staging-master.xml
@@ -23,4 +23,5 @@
   <include file="db/changelog/changeset/0017_tenant_dpa_signature_token/0017-changeSet.xml"/>
   <include file="db/changelog/changeset/0018_tenant_dpa_version/0018-changeSet.xml"/>
   <include file="db/changelog/changeset/0019_tenant_dpa_signature_audit_fields/0019-changeSet.xml"/>
+  <include file="db/changelog/changeset/0020_fix_dpa_sequence_name_case/0020-changeSet.xml"/>
 </databaseChangeLog>

--- a/src/test/java/com/vi/tenantservice/api/converter/TenantConverterTest.java
+++ b/src/test/java/com/vi/tenantservice/api/converter/TenantConverterTest.java
@@ -136,6 +136,45 @@ class TenantConverterTest {
   }
 
   @Test
+  void toRestrictedTenantDTO_should_exposeRawLanguageMapsIncludingTranslationMeta()
+      throws TemplateDescriptionServiceException {
+    // given
+    var impressumJson =
+        "{\"de\":\"<h2 id=\\\"intro\\\">Impressum</h2>\",\"en\":\"<h2>Imprint</h2>\","
+            + "\"en__meta\":\"{\\\"mt\\\":true,\\\"src\\\":\\\"de\\\",\\\"at\\\":\\\"2026-07-04T10:00:00Z\\\"}\"}";
+    var privacyJson =
+        "{\"de\":\"<p>Datenschutz</p>\",\"en\":\"<p>Privacy</p>\","
+            + "\"en__meta\":\"{\\\"mt\\\":true,\\\"src\\\":\\\"de\\\",\\\"at\\\":\\\"2026-07-04T10:00:00Z\\\"}\"}";
+    var entity = new TenantEntity();
+    entity.setId(5L);
+    entity.setName("tenant");
+    entity.setContentImpressum(impressumJson);
+    entity.setContentPrivacy(privacyJson);
+    when(templateService.getMultilingualDataProtectionTemplate()).thenReturn(Map.of());
+
+    // when
+    RestrictedTenantDTO restrictedTenantDTO =
+        tenantConverter.toRestrictedTenantDTO(entity, TenantConverter.DE);
+
+    // then: resolved fields are unchanged
+    assertThat(restrictedTenantDTO.getContent().getImpressum())
+        .isEqualTo("<h2 id=\"intro\">Impressum</h2>");
+    assertThat(restrictedTenantDTO.getContent().getPrivacy()).isEqualTo("<p>Datenschutz</p>");
+
+    // and: the raw language maps incl. __meta keys are exposed as stored (no processing)
+    assertThat(restrictedTenantDTO.getContent().getImpressumLanguages())
+        .containsOnly(
+            Map.entry("de", "<h2 id=\"intro\">Impressum</h2>"),
+            Map.entry("en", "<h2>Imprint</h2>"),
+            Map.entry("en__meta", "{\"mt\":true,\"src\":\"de\",\"at\":\"2026-07-04T10:00:00Z\"}"));
+    assertThat(restrictedTenantDTO.getContent().getPrivacyLanguages())
+        .containsOnly(
+            Map.entry("de", "<p>Datenschutz</p>"),
+            Map.entry("en", "<p>Privacy</p>"),
+            Map.entry("en__meta", "{\"mt\":true,\"src\":\"de\",\"at\":\"2026-07-04T10:00:00Z\"}"));
+  }
+
+  @Test
   void toRestrictedTenantDTO_should_redactSensitivePublicSettings() {
     // given
     MultilingualTenantDTO tenantDTO =

--- a/src/test/java/com/vi/tenantservice/api/service/SingleDomainTenantOverrideServiceTest.java
+++ b/src/test/java/com/vi/tenantservice/api/service/SingleDomainTenantOverrideServiceTest.java
@@ -11,6 +11,7 @@ import com.vi.tenantservice.api.model.TenantEntity;
 import com.vi.tenantservice.api.service.consultingtype.ApplicationSettingsService;
 import com.vi.tenantservice.applicationsettingsservice.generated.web.model.FeatureToggleDTO;
 import java.time.LocalDateTime;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -55,6 +56,8 @@ class SingleDomainTenantOverrideServiceTest {
 
     // then
     assertThat(restrictedTenantDTO.getContent().getPrivacy()).isEqualTo("actual privacy");
+    assertThat(restrictedTenantDTO.getContent().getPrivacyLanguages())
+        .isEqualTo(Map.of("de", "actual privacy"));
     assertThat(restrictedTenantDTO.getContent().getDataPrivacyConfirmation())
         .isEqualTo(actualPrivacyChangedDate);
     assertThat(restrictedTenantDTO.getSettings().getFeatureAttachmentUploadDisabled()).isTrue();
@@ -97,7 +100,11 @@ class SingleDomainTenantOverrideServiceTest {
   private static RestrictedTenantDTO restrictedDTO(
       String privacy, LocalDateTime privacyChangedDate, boolean featureAttachmentUploadDisabled) {
     return new RestrictedTenantDTO()
-        .content(new Content().privacy(privacy).dataPrivacyConfirmation(privacyChangedDate))
+        .content(
+            new Content()
+                .privacy(privacy)
+                .privacyLanguages(Map.of("de", privacy))
+                .dataPrivacyConfirmation(privacyChangedDate))
         .settings(new Settings().featureAttachmentUploadDisabled(featureAttachmentUploadDisabled));
   }
 }

--- a/src/test/java/com/vi/tenantservice/api/validation/InputSanitizerTest.java
+++ b/src/test/java/com/vi/tenantservice/api/validation/InputSanitizerTest.java
@@ -1,0 +1,75 @@
+package com.vi.tenantservice.api.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class InputSanitizerTest {
+
+  private final InputSanitizer inputSanitizer = new InputSanitizer();
+
+  // --- Anchor navigation support (Admin anchor feature): id + data-anchor-removed on headings ---
+
+  @Test
+  void sanitizeAllowingFormattingAndLinks_should_keepIdOnHeadings() {
+    var input = "<h2 id=\"intro\">Intro</h2><h3 id=\"data-usage_2\">Data usage</h3>";
+
+    var result = inputSanitizer.sanitizeAllowingFormattingAndLinks(input);
+
+    assertThat(result).contains("<h2 id=\"intro\">");
+    assertThat(result).contains("<h3 id=\"data-usage_2\">");
+  }
+
+  @Test
+  void sanitizeAllowingFormattingAndLinks_should_keepDataAnchorRemovedTrueOnHeadings() {
+    var input = "<h2 data-anchor-removed=\"true\">Old chapter</h2>";
+
+    var result = inputSanitizer.sanitizeAllowingFormattingAndLinks(input);
+
+    assertThat(result).contains("data-anchor-removed=\"true\"");
+  }
+
+  @Test
+  void sanitizeAllowingFormattingAndLinks_should_dropIdWithUnsafeCharacters() {
+    var javascriptLike = "<h2 id=\"javascript:alert(1)\">x</h2>";
+    var withQuotes = "<h2 id=\"intro&quot;onmouseover=alert(1)\">x</h2>";
+    var withSpaces = "<h2 id=\"intro chapter\">x</h2>";
+
+    assertThat(inputSanitizer.sanitizeAllowingFormattingAndLinks(javascriptLike))
+        .doesNotContain("id=");
+    assertThat(inputSanitizer.sanitizeAllowingFormattingAndLinks(withQuotes)).doesNotContain("id=");
+    assertThat(inputSanitizer.sanitizeAllowingFormattingAndLinks(withSpaces)).doesNotContain("id=");
+  }
+
+  @Test
+  void sanitizeAllowingFormattingAndLinks_should_dropDataAnchorRemovedWithOtherValues() {
+    var input = "<h2 data-anchor-removed=\"false\">x</h2>";
+
+    var result = inputSanitizer.sanitizeAllowingFormattingAndLinks(input);
+
+    assertThat(result).doesNotContain("data-anchor-removed");
+  }
+
+  @Test
+  void sanitizeAllowingFormattingAndLinks_should_notAllowIdOnNonHeadingElements() {
+    var input = "<p id=\"intro\">text</p><a id=\"intro\" href=\"http://oriso.org\">link</a>";
+
+    var result = inputSanitizer.sanitizeAllowingFormattingAndLinks(input);
+
+    assertThat(result).doesNotContain("id=");
+  }
+
+  @Test
+  void sanitizeAllowingFormattingAndLinks_should_stillStripScriptInjection() {
+    var input =
+        "<h2 id=\"intro\">Intro</h2><script>alert(1)</script>"
+            + "<img src=\"x\" onerror=\"alert(1)\" /><h2 onclick=\"alert(1)\">x</h2>";
+
+    var result = inputSanitizer.sanitizeAllowingFormattingAndLinks(input);
+
+    assertThat(result).doesNotContain("script");
+    assertThat(result).doesNotContain("onerror");
+    assertThat(result).doesNotContain("onclick");
+    assertThat(result).contains("<h2 id=\"intro\">");
+  }
+}


### PR DESCRIPTION
## What users saw

Three bugs, all found by the 2026-07-04 Playwright real-click gate:

1. **Publishing the DPA crashed on fresh databases.** A Träger admin clicked "publish" on the data processing agreement and got an error page (HTTP 500). Cause: the database sequences were created with UPPERCASE names, but the app asks for lowercase names at runtime. On case-sensitive Linux MariaDB the insert dies with `Unknown SEQUENCE: 'sequence_tenant_dpa_version'`. Every fresh Liquibase bootstrap is broken this way; the same hit the signature insert.
2. **Removed anchors came back after reload.** In the legal-content editor (anchor navigation, Admin #234), heading anchors like `<h2 id="intro">` and the `data-anchor-removed="true"` marker were stripped by the HTML sanitizer on save. After a reload the editor saw plain headings again, so anchors vanished and explicitly removed anchors resurrected.
3. **Users never saw the machine-translation notice.** The public tenant endpoints resolve imprint/privacy to a single string server-side and drop the `__meta` translation-metadata keys. The frontend had no way to show "this page is machine translated - the German version is legally binding".

## Fixes (one commit per bug)

1. **New changeset 0020** (0016/0018 stay untouched): renames the uppercase sequences to lowercase (`RENAME TABLE`, precondition-guarded: only when uppercase exists and lowercase does not) and creates the lowercase ones `IF NOT EXISTS` as a fallback. Environments that already have both casings (e.g. Pre-Dev) are left alone. Wired into the dev/local/prod/staging masters.
2. **Sanitizer policy** now allows on h1-h6: `id` restricted to `[a-zA-Z0-9_-]+` (no colons/quotes/spaces, XSS surface stays zero) and `data-anchor-removed` only with the exact value `true`.
3. **Additive API change:** `Content` gains optional `impressumLanguages` / `privacyLanguages` - the raw stored language map incl. `<lang>__meta` keys, exposed on all public tenant endpoints. Resolved string fields are unchanged; only imprint + privacy get raw maps to keep the payload lean.

## Validation

**Bug 1** - throwaway MariaDB 10.11 (`lower_case_table_names=0`) + liquibase 4.29:
- RED (before fix): fresh chain -> `SELECT NEXTVAL(sequence_tenant_dpa_version)` fails with ERROR 4091
- fresh bootstrap of the full new chain: only lowercase sequences remain, `NEXTVAL` works
- re-run: idempotent (0 changesets executed)
- upgrade path from an uppercase-only database: renamed correctly
- both-casings state (Pre-Dev-like): renames `MARK_RAN`, no error, nothing touched

**Bug 2** - TDD: 6 new `InputSanitizerTest` tests (red first, then green): id + marker survive, `javascript:`-ish / quoted / spaced id values are dropped, id disallowed outside headings, `<script>`/`onerror`/`onclick` still stripped. Existing sanitizer tests stay green.

**Bug 3** - TDD: new converter test (raw maps incl. `en__meta` exposed unchanged, resolved strings unchanged) and single-domain override test (privacyLanguages follows the overridden privacy) - red first, then green.

Full suite: 180 tests, 0 failures. `spotless:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)