### PR TITLE
ci: run integration tests (verify) + harden the unit-test gate

### DIFF
--- a/.github/actions/maven-build/action.yml
+++ b/.github/actions/maven-build/action.yml
@@ -1,9 +1,8 @@
-name: Reusable Maven Build steps
+name: Reusable Maven validation and build steps
 
 inputs:
-  java_version: 
+  java_version:
     required: true
-    type: string
 
 runs:
   using: 'composite'
@@ -14,11 +13,35 @@ runs:
       java-version: ${{ inputs.java_version }}
       distribution: 'temurin'
       cache: maven
-      
-  - name: Build with Maven Wrapper
-    shell: bash
-    run: ./mvnw -B package
 
-  # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-  #- name: Update dependency graph
-  #  uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
+  # Blocking unit-test gate (Test Quality Audit 2026-07-04, item 3).
+  # Runs the surefire `unit-tests` execution (test phase, **/*Test) and fails the
+  # build if any report shows failures/errors. Previously CI ran only
+  # `mvnw -B package`, which prints BUILD SUCCESS even when tests fail.
+  - name: Run Maven tests
+    shell: bash
+    run: |
+      ./mvnw -B test
+      python3 - <<'PY'
+      from pathlib import Path
+      import sys
+      import xml.etree.ElementTree as ET
+
+      failing_reports = []
+      for report in Path("target/surefire-reports").glob("TEST-*.xml"):
+          root = ET.parse(report).getroot()
+          failures = int(root.attrib.get("failures", 0))
+          errors = int(root.attrib.get("errors", 0))
+          if failures or errors:
+              failing_reports.append((report, failures, errors))
+
+      if failing_reports:
+          print("Maven reported test failures/errors:")
+          for report, failures, errors in failing_reports:
+              print(f"- {report}: failures={failures}, errors={errors}")
+          sys.exit(1)
+      PY
+
+  - name: Package Java application
+    shell: bash
+    run: ./mvnw -B package -DskipTests

--- a/.github/actions/maven-verify-burnin/action.yml
+++ b/.github/actions/maven-verify-burnin/action.yml
@@ -1,0 +1,92 @@
+name: Reusable Maven integration-test burn-in
+
+# Burn-in action (Test Quality Audit 2026-07-04, item 3 + CI Roadmap Part 1).
+# Runs the full `verify` lifecycle so the surefire `integration-tests` execution
+# (bound to the integration-test phase, includes **/*IT.*) actually runs. These
+# integration tests have never run in CI before, so this action is wired into a
+# NON-BLOCKING (continue-on-error) job. It must NOT be a required check until the
+# ITs are green. `mvnw` is run with `-fae` so IT failures are visible in the job
+# summary and reports without aborting the report-collection step below.
+
+inputs:
+  java_version:
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+  - name: Set up JDK and Maven
+    uses: actions/setup-java@v5
+    with:
+      java-version: ${{ inputs.java_version }}
+      distribution: 'temurin'
+      cache: maven
+
+  - name: Run Maven verify (unit + integration tests, burn-in)
+    shell: bash
+    # -fae (fail-at-end) lets every module/execution run so the report set is
+    # complete; the actual pass/fail signal comes from the report gate below,
+    # which this burn-in job tolerates (continue-on-error at the job level).
+    run: ./mvnw -B -fae verify
+
+  - name: Assert test reports were produced (zero-report guard)
+    if: ${{ always() }}
+    shell: bash
+    # Guards against a future silent-skip: a green build that produced ZERO test
+    # reports must be treated as a failure, not a pass. Surefire writes both the
+    # unit (**/*Test) and integration (**/*IT) executions into surefire-reports;
+    # failsafe-reports is globbed too in case a module adopts failsafe later.
+    run: |
+      shopt -s nullglob globstar
+      reports=( **/target/surefire-reports/TEST-*.xml **/target/failsafe-reports/TEST-*.xml )
+      count=${#reports[@]}
+      echo "Found ${count} test report file(s)."
+      if [ "${count}" -eq 0 ]; then
+        echo "::error::Zero test reports were produced — tests were silently skipped or never ran."
+        exit 1
+      fi
+
+  - name: Summarise integration-test results (burn-in)
+    if: ${{ always() }}
+    shell: bash
+    run: |
+      python3 - <<'PY'
+      from pathlib import Path
+      import xml.etree.ElementTree as ET
+
+      total_tests = total_failures = total_errors = total_skipped = 0
+      failing = []
+      for report in Path(".").glob("**/target/surefire-reports/TEST-*.xml"):
+          try:
+              root = ET.parse(report).getroot()
+          except ET.ParseError:
+              continue
+          tests = int(root.attrib.get("tests", 0))
+          failures = int(root.attrib.get("failures", 0))
+          errors = int(root.attrib.get("errors", 0))
+          skipped = int(root.attrib.get("skipped", 0))
+          total_tests += tests
+          total_failures += failures
+          total_errors += errors
+          total_skipped += skipped
+          if failures or errors:
+              failing.append((report, failures, errors))
+
+      print(f"Integration-test burn-in: tests={total_tests} "
+            f"failures={total_failures} errors={total_errors} skipped={total_skipped}")
+      if failing:
+          print("Reports with failures/errors (expected during burn-in):")
+          for report, failures, errors in sorted(failing):
+              print(f"- {report}: failures={failures}, errors={errors}")
+      PY
+
+  - name: Upload test reports
+    if: ${{ always() }}
+    uses: actions/upload-artifact@v4
+    with:
+      name: integration-test-reports-${{ inputs.java_version }}
+      path: |
+        **/target/surefire-reports/*.xml
+        **/target/failsafe-reports/*.xml
+      if-no-files-found: warn
+      retention-days: 7

--- a/.github/workflows/ci-feature-branch.yml
+++ b/.github/workflows/ci-feature-branch.yml
@@ -18,3 +18,20 @@ jobs:
       uses: ./.github/actions/maven-build
       with:
         java_version: '21'
+
+  # Non-blocking burn-in (Test Quality Audit 2026-07-04, item 3 + CI Roadmap Part 1).
+  # Runs `mvnw -B verify` so the integration-test phase (46 *IT tests) runs on
+  # feature branches too. continue-on-error keeps it non-blocking during burn-in.
+  integration-tests:
+    name: integration-tests (non-blocking, burn-in)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Run integration tests (verify)
+      uses: ./.github/actions/maven-verify-burnin
+      with:
+        java_version: '21'

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -33,3 +33,21 @@ jobs:
         push_to_ghcr: true
         image_name: oriso-tenantservice
         github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Non-blocking burn-in (Test Quality Audit 2026-07-04, item 3 + CI Roadmap Part 1).
+  # Runs `mvnw -B verify` on dev/main so integration-test results stay visible after
+  # merge. Independent of the publish job: a red burn-in must NOT block publishing
+  # while the ITs are being stabilised. Flip to required once burn-in is green.
+  integration-tests:
+    name: integration-tests (non-blocking, burn-in)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Run integration tests (verify)
+      uses: ./.github/actions/maven-verify-burnin
+      with:
+        java_version: '21'

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -26,3 +26,23 @@ jobs:
         push_to_ghcr: false
         image_name: oriso-tenantservice
         github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Non-blocking burn-in (Test Quality Audit 2026-07-04, item 3 + CI Roadmap Part 1).
+  # Runs `mvnw -B verify`, which reaches the surefire `integration-tests` execution
+  # (integration-test phase, **/*IT.*) — the 46 authz/actuator ITs that have never
+  # run in CI. They use embedded H2 + in-process WireMock + Mockito, so no external
+  # services are needed. continue-on-error keeps this OFF the required-checks path
+  # until burn-in is consistently green; flip to required once it is.
+  integration-tests:
+    name: integration-tests (non-blocking, burn-in)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Run integration tests (verify)
+      uses: ./.github/actions/maven-verify-burnin
+      with:
+        java_version: '21'


### PR DESCRIPTION
## What changed

Two related CI fixes.

**1. Harden the blocking unit gate.** CI ran only `./mvnw -B package`, which prints `BUILD SUCCESS` even when tests fail and never enforced test results at all. The `maven-build` action now runs the tests and fails on failures/errors.

**2. Add integration-test burn-in.** `mvn package` stops **before** the `integration-test` phase, so the surefire `integration-tests` execution (bound to `integration-test`, includes `**/*IT.*`) never ran — the **46** authz/actuator ITs were dormant. A new **non-blocking** job runs `verify`.

**Maven invocation — before → after (per job):**

| Job | Before | After |
| --- | --- | --- |
| build gate (`maven-build`, **blocking**) | `./mvnw -B package` (no test-result enforcement) | `./mvnw -B test` + surefire-failure guard, then `./mvnw -B package -DskipTests` |
| `integration-tests` (**new, non-blocking burn-in**) | — | `./mvnw -B -fae verify` + zero-report guard |

Files:
- `.github/actions/maven-build/action.yml` — split into a test step (with a failure guard) + a package step; brings TenantService up to the UserService standard.
- **New** `.github/actions/maven-verify-burnin/action.yml` — runs `verify`, a zero-report guard, an IT summary, and uploads reports.
- `.github/workflows/ci-pull-request.yml`, `ci-feature-branch.yml`, `ci-main.yml` — add the `integration-tests (non-blocking, burn-in)` job.

## Burn-in, not big-bang (rationale)

The 46 ITs have **never run in CI**. The new job is a **separate job with `continue-on-error: true`**, named `integration-tests (non-blocking, burn-in)`, so results are visible in every PR and on `dev`/`main` without gating merges. The (now hardened) unit-test gate stays blocking.

**Action item:** flip the burn-in job to a required status check once it is consistently green.

## Zero-report guard

The burn-in action fails the job if **zero** test report XMLs were produced (`**/target/surefire-reports/TEST-*.xml` + `**/target/failsafe-reports/TEST-*.xml`), guarding against a future silent test-skip. `verify` runs with `-fae` so the report set is complete even when some ITs fail.

## Expected-red ITs + services needed

Infra analysis (this audit): the 46 ITs — `TenantControllerIT` (42), `ActuatorControllerIT` (3), `RestTemplateConfigIT` (1) — run against **embedded H2** with `@Sql` seed scripts + **in-process WireMock** + Mockito beans; downstream services (ConsultingType, UserAdmin, AuthorisationService, …) are `@MockitoBean`. **No external MariaDB / Keycloak / Testcontainers are required** (no testcontainers dependency exists). The `<excludedGroups>SkipOnCI</excludedGroups>` in surefire is currently a no-op (nothing is tagged). The `@DataJpaTest` repo tests that historically failed on bare machines are now self-provisioning against H2.

So the 46 ITs are **expected to pass** on a bare `ubuntu-latest` runner. Any that surprise us feed the audit roadmap Part 2.

---

Test Quality Audit 2026-07-04, item 3 + CI Roadmap Part 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
