### PR TITLE
fix(deploy): point deploy-development.sh JAVA_HOME to Java 21 (audit item 7)

### DIFF
--- a/deploy-development.sh
+++ b/deploy-development.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 NAMESPACE=${NAMESPACE:-caritas}
 DEPLOYMENT=${DEPLOYMENT:-oriso-platform-tenantservice}
-export JAVA_HOME=${JAVA_HOME:-/usr/lib/jvm/java-17-openjdk-amd64}
+# TenantService builds on Java 21 since the 2026-07 upgrade; the old
+# java-17 default no longer exists on the deploy host and broke this script.
+export JAVA_HOME=${JAVA_HOME:-/usr/lib/jvm/java-21-openjdk-amd64}
 export PATH="$JAVA_HOME/bin:$PATH"
 
 echo "Starting TenantService build & deployment..."


### PR DESCRIPTION
Part of **Test Quality Audit 2026-07-04, item 7** (broken JAVA_HOME in deploy scripts).

`deploy-development.sh` hardcoded `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64`, which **no longer exists on the deploy host** after this week's Java 21 upgrade — so the `mvn package` step in the script failed.

**Change:** default `JAVA_HOME` to `/usr/lib/jvm/java-21-openjdk-amd64`, keeping the `${JAVA_HOME:-…}` override pattern so callers can still point elsewhere.

**Verified:** `/usr/lib/jvm/java-21-openjdk-amd64` is present on the deploy host (probed the deploy host directly); `bash -n` passes on the edited script.

**Scope note:** this touches only the shell **deploy script**, not `.github` Maven workflows (which a sibling agent owns) — no overlap. Per the ORISO-Helm-canonical rule these server-side deploy scripts should eventually **move into ORISO-Helm**; fixed in place here to unblock deploys now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
