### PR TITLE
fix(tenant): match settings column length to Liquibase; turn TenantControllerIT green

### DIFF
--- a/src/main/java/com/vi/tenantservice/api/model/TenantEntity.java
+++ b/src/main/java/com/vi/tenantservice/api/model/TenantEntity.java
@@ -83,7 +83,7 @@ public class TenantEntity implements TenantData {
   @Column(name = "dpa_activation_date")
   private LocalDateTime contentDataProcessingAgreementActivationDate;
 
-  @Column(name = "settings")
+  @Column(name = "settings", length = 4000)
   private String settings;
 
   @Column(name = "create_date", nullable = false)

--- a/src/main/resources/application-testing.properties
+++ b/src/main/resources/application-testing.properties
@@ -30,6 +30,12 @@ spring.liquibase.enabled=false
 
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=true
+
+# Default tenant settings applied to newly created tenants. Points at the test
+# fixture so createTenant integration tests exercise real default-settings loading
+# instead of falling back to empty defaults. Relative to the module root (the test
+# working directory).
+default.tenant.settings.json.path=src/test/resources/settings/default-tenant-settings.json
 spring.jpa.properties.hibernate.format_sql=true
 server.port = 8081
 feature.multitenancy.with.single.domain.enabled=false

--- a/src/test/java/com/vi/tenantservice/api/controller/TenantControllerIT.java
+++ b/src/test/java/com/vi/tenantservice/api/controller/TenantControllerIT.java
@@ -951,7 +951,10 @@ class TenantControllerIT {
         .andExpect(jsonPath("$[0].name").exists())
         .andExpect(jsonPath("$[0].subdomain").exists())
         .andExpect(jsonPath("$[0].beraterCount").exists())
-        .andExpect(jsonPath("$[0].adminEmails").doesNotExist());
+        // No tenant admins are mocked here, so the enrichment step leaves adminEmails untouched.
+        // The generated AdminTenantDTO now default-initializes the field to an empty list, so it
+        // serializes as an empty array rather than being absent.
+        .andExpect(jsonPath("$[0].adminEmails", hasSize(0)));
   }
 
   // --- machine-translation provider API keys (platform-global, super admin only) ---

--- a/src/test/resources/database/MultiTenantData.sql
+++ b/src/test/resources/database/MultiTenantData.sql
@@ -7,3 +7,10 @@ INSERT INTO TENANT (`id`, `name`, `subdomain`, `licensing_allowed_users`, `conte
                   VALUES (2, 'Another tenant', 'examplesubdomain', 10, '{"de" : "Impressum"}', '{ "de" : "Privacy"}','2021-12-28', '2021-12-29', '{"topicsInRegistrationEnabled":"true"}');
 INSERT INTO TENANT (`id`, `name`, `subdomain`, `licensing_allowed_users`, `content_impressum`,`content_privacy`,  `create_date`, `update_date`,`settings`)
                   VALUES (3, 'localhost tenant', 'localhost', 12, '{"de" : "Impressum"}', '{ "de" : "Privacy"}','2021-12-28', '2021-12-29', '{"topicsInRegistrationEnabled":"true"}');
+
+-- Move the id sequence past the seeded rows (max id = 3) so createTenant tests do
+-- not collide with the fixed ids above. Under ddl-auto=create-drop Hibernate already
+-- created SEQUENCE_TENANT (from the entity's @SequenceGenerator, starting at 1), so the
+-- "CREATE SEQUENCE IF NOT EXISTS ... START WITH 100000" in TenantServiceDatabase.sql is a
+-- no-op. Mirrors the approach already used in TenantRepositoryTestData.sql.
+ALTER SEQUENCE SEQUENCE_TENANT RESTART WITH 100000;


### PR DESCRIPTION
## Why

`TenantControllerIT` was the only red IT in the TenantService verify suite (4 errors + 1 stale assertion), keeping the module at 3/4 verify-green. This makes it **4/4**.

## Root cause — VARCHAR(255) overflow

`TenantEntity.settings` had **no `length`** on its `@Column` mapping. Under the `testing` profile the H2 test schema is derived from the entity via `ddl-auto=create-drop`, so the column became **`VARCHAR(255)`**. The real production column is **`VARCHAR(4000)`** — defined in Liquibase changeset `0005_change_tenant_settings_structure/migrateToGeneralSettings.sql`:

```sql
ALTER TABLE `tenantservice`.`tenant` ADD COLUMN `settings` VARCHAR(4000) NULL ...
```

Serialized tenant-settings JSON (~1.6 kB) overflowed 255 → 4 errors:

```
DataIntegrityViolationException: Wert zu groß / lang für Feld "SETTINGS CHARACTER VARYING(255)" ... (1579)
```

### Fix
`@Column(name = "settings", length = 4000)` — mirrors the Liquibase column **exactly**. This also removes a genuine **entity/schema divergence**: the entity's implicit 255 contradicted the 4000-char production column, so the JPA mapping was wrong even in production (the DB tolerated it because MariaDB's column was already 4000; the entity just never advertised it). The Liquibase schema is **not** changed here — only the entity mapping is brought into line with it.

## Two latent bugs the overflow was masking

Once inserts stopped truncating, two further failures surfaced that had never been reached before:

1. **Sequence PK collision.** Under `ddl-auto=create-drop`, Hibernate creates `SEQUENCE_TENANT` (from the entity's `@SequenceGenerator`) starting at **1**, so the `CREATE SEQUENCE IF NOT EXISTS ... START WITH 100000` in `TenantServiceDatabase.sql` is a **no-op**. `createTenant` then allocated ids 1,2,… colliding with seeded tenants 0–3. Added `ALTER SEQUENCE SEQUENCE_TENANT RESTART WITH 100000;` to `MultiTenantData.sql` — **mirroring the approach already used in `TenantRepositoryTestData.sql`**.

2. **Empty default settings on create.** The `testing` profile never set `default.tenant.settings.json.path`, so `getDefaultTenantSettings()` returned empty defaults and `createTenant` returned settings with every flag `false`. Wired the property to the existing fixture `src/test/resources/settings/default-tenant-settings.json`, so the `createTenant` IT now exercises **real** default-settings loading (its assertions match the fixture exactly).

## Stale assertion fix (adminEmails)

`getAllTenantsWithAdminData_Should_returnAdminTenantDTOs_...` asserted `$[0].adminEmails` **doesNotExist()**. The generated `AdminTenantDTO` now default-initializes `adminEmails = new ArrayList<>()` (OpenAPI generator behavior after the Java 21 / Spring Boot 4 upgrade), so with no admins mocked the field serializes as an **empty array**, not absent. Corrected to `hasSize(0)` — this **pins the current, correct behavior** rather than weakening the check.

## Before / after — `TenantControllerIT`

| | Tests | Failures | Errors |
|---|---|---|---|
| **Before** | 44 | 1 | 4 |
| **After** | 44 | 0 | 0 |

Full `verify` is green: **252 unit + 50 IT** (3 IT skipped by design — `LiquibaseSchemaDriftIT`). Makes the TenantService verify suite flip-ready (**TS-VERIFY-1/2**).

## Scope / collision
Change is confined to the `TenantEntity` mapping, the IT assertion, one test seed script, and the `testing` profile property. Surveyed open PRs (#65, #64, #50, #33) — **none touch `TenantEntity.java` or `TenantControllerIT.java`**. No `.github/` or deploy-script changes (owned by other PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)