### PR TITLE
fix(api): replace invalid OpenAPI scalar 'type: long' with integer/int64

### DIFF
--- a/api/tenantservice.yaml
+++ b/api/tenantservice.yaml
@@ -398,7 +398,8 @@ paths:
           description: Tenant Id
           required: false
           schema:
-            type: long
+            type: integer
+            format: int64
       responses:
         200:
           description: Successful operation
@@ -426,7 +427,8 @@ paths:
           description: Tenant ID
           required: true
           schema:
-            type: long
+            type: integer
+            format: int64
       responses:
         200:
           description: Successful operation
@@ -548,7 +550,8 @@ paths:
           description: Tenant ID
           required: true
           schema:
-            type: long
+            type: integer
+            format: int64
       responses:
         200:
           description: Successful operation
@@ -575,7 +578,8 @@ paths:
           description: Tenant ID
           required: true
           schema:
-            type: long
+            type: integer
+            format: int64
       responses:
         200:
           description: Successful operation
@@ -600,7 +604,8 @@ paths:
           description: Tenant ID
           required: true
           schema:
-            type: long
+            type: integer
+            format: int64
       responses:
         200:
           description: Successful operation
@@ -627,7 +632,8 @@ paths:
           description: Tenant ID
           required: true
           schema:
-            type: long
+            type: integer
+            format: int64
       requestBody:
         required: true
         description: 'Per-language DPA HTML content (language code -> HTML). Supports the
@@ -671,7 +677,8 @@ paths:
           description: Tenant ID
           required: true
           schema:
-            type: long
+            type: integer
+            format: int64
       responses:
         200:
           description: Successful operation
@@ -868,7 +875,8 @@ components:
         - subdomain
       properties:
         id:
-          type: long
+          type: integer
+          format: int64
           example: 12132
         name:
           type: string
@@ -906,7 +914,8 @@ components:
             - name
           properties:
             id:
-              type: long
+              type: integer
+              format: int64
               example: 12132
             name:
               type: string
@@ -951,7 +960,8 @@ components:
         - subdomain
       properties:
         id:
-          type: long
+          type: integer
+          format: int64
           example: 12132
         name:
           type: string
@@ -974,7 +984,8 @@ components:
         - name
       properties:
         id:
-          type: long
+          type: integer
+          format: int64
           example: 12132
         name:
           type: string
@@ -1423,7 +1434,8 @@ components:
         - subdomain
       properties:
         id:
-          type: long
+          type: integer
+          format: int64
           example: 12132
         name:
           type: string

--- a/services/agencyadminservice.yaml
+++ b/services/agencyadminservice.yaml
@@ -406,7 +406,8 @@ components:
       type: object
       properties:
         id:
-          type: long
+          type: integer
+          format: int64
           example: 12132
         name:
           type: string
@@ -576,7 +577,8 @@ components:
         topicIds:
           type: array
           items:
-            type: long
+            type: integer
+            format: int64
         demographics:
           $ref: '#/components/schemas/DemographicsDTO'
         tenantId:
@@ -646,7 +648,8 @@ components:
         topicIds:
           type: array
           items:
-            type: long
+            type: integer
+            format: int64
         demographics:
           $ref: '#/components/schemas/DemographicsDTO'
         counsellingRelations:


### PR DESCRIPTION
## What
Replaces all 15 occurrences of the invalid OpenAPI scalar `type: long` with `type: integer` + `format: int64` in `api/tenantservice.yaml` (12) and `services/agencyadminservice.yaml` (3).

## Why
`long` is not a valid OpenAPI data type. The Java generator tolerates it, but downstream type generators break on it — ORISO-Frontend's `dtsgen.ts` needed a normalization workaround because of this (see OpenResilienceInitiative/ORISO-Frontend#384). This fixes the canonical source here; the vendored copies in the sibling repos are fixed in parallel PRs (CTS#52, AS#107, US#329).

## Verification
`./mvnw -B compile` green (openapi-generator runs in generate-sources; `integer/int64` still maps to `Long`). No schema-semantics change — the wire format (JSON number) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
