### PR TITLE
Merge pre-dev into dev

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -33,6 +33,7 @@ runs:
         type=sha
         type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
         type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
+        type=raw,value=pre-dev,enable=${{ github.ref == 'refs/heads/pre-dev' }}
       
   - name: Build and Push Docker image
     id: build

--- a/.github/workflows/ci-feature-branch.yml
+++ b/.github/workflows/ci-feature-branch.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore: 
     - main
     - dev
+    - pre-dev
 
 jobs:
   build:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dev
+      - pre-dev
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Syncs `dev` with the latest `pre-dev` changes. `pre-dev` is ahead of `dev` with no divergent commits on `dev` (clean fast-forward relationship).

## Commits
- ci: build pre-dev branch (mirror dev pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)