### PR TITLE
feat: add group chat author translation

### DIFF
--- a/api/tenantservice.yaml
+++ b/api/tenantservice.yaml
@@ -264,6 +264,48 @@ paths:
                 $ref: '#/components/schemas/TranslationErrorDTO'
         500:
           description: INTERNAL SERVER ERROR - server encountered unexpected condition
+  /tenant/translate/group-chat-author-content:
+    post:
+      tags:
+        - tenant-controller
+      summary: 'Translates bounded self-help group welcome and rule content [Authorization: consultant]'
+      description: 'Uses the configured translation provider for short, plain-text welcome and
+        group-rule content. The endpoint is intentionally separate from tenant administration so
+        consultants never receive tenant-management privileges.'
+      operationId: translateGroupChatAuthorContent
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TranslationRequestDTO'
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TranslationResponseDTO'
+        400:
+          description: BAD REQUEST - content is missing or exceeds the group-chat limits
+        401:
+          description: UNAUTHORIZED - no/invalid Keycloak token
+        403:
+          description: FORBIDDEN - dedicated group-chat translation authority is missing
+        409:
+          description: CONFLICT - no translation provider API key configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TranslationErrorDTO'
+        502:
+          description: BAD GATEWAY - translation provider error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TranslationErrorDTO'
+        500:
+          description: INTERNAL SERVER ERROR - server encountered unexpected condition
   /tenantadmin/{id}:
     put:
       tags:

--- a/api/tenantservice.yaml
+++ b/api/tenantservice.yaml
@@ -268,7 +268,7 @@ paths:
     post:
       tags:
         - tenant-controller
-      summary: 'Translates bounded self-help group welcome and rule content [Authorization: consultant]'
+      summary: 'Translates bounded self-help group welcome and rule content [Authorization: consultant, group-chat-consultant]'
       description: 'Uses the configured translation provider for short, plain-text welcome and
         group-rule content. The endpoint is intentionally separate from tenant administration so
         consultants never receive tenant-management privileges.'

--- a/src/main/java/com/vi/tenantservice/api/authorisation/Authority.java
+++ b/src/main/java/com/vi/tenantservice/api/authorisation/Authority.java
@@ -14,6 +14,9 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum Authority {
+  CONSULTANT(UserRole.CONSULTANT, singletonList(AuthorityValue.TRANSLATE_GROUP_CHAT_CONTENT)),
+  GROUP_CHAT_CONSULTANT(
+      UserRole.GROUP_CHAT_CONSULTANT, singletonList(AuthorityValue.TRANSLATE_GROUP_CHAT_CONTENT)),
   TENANT_ADMIN(
       UserRole.TENANT_ADMIN,
       Lists.newArrayList(
@@ -62,5 +65,7 @@ public enum Authority {
 
     public static final String UPDATE_EXTENDED_TENANT_SETTINGS =
         PREFIX + "UPDATE_EXTENDED_TENANT_SETTINGS";
+    public static final String TRANSLATE_GROUP_CHAT_CONTENT =
+        PREFIX + "TRANSLATE_GROUP_CHAT_CONTENT";
   }
 }

--- a/src/main/java/com/vi/tenantservice/api/authorisation/UserRole.java
+++ b/src/main/java/com/vi/tenantservice/api/authorisation/UserRole.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum UserRole {
+  CONSULTANT("consultant"),
+  GROUP_CHAT_CONSULTANT("group-chat-consultant"),
   TENANT_ADMIN("tenant-admin"),
   SINGLE_TENANT_ADMIN("single-tenant-admin"),
 

--- a/src/main/java/com/vi/tenantservice/api/controller/TenantController.java
+++ b/src/main/java/com/vi/tenantservice/api/controller/TenantController.java
@@ -51,6 +51,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.server.ResponseStatusException;
 
 /** Controller for tenant API operations. */
 @RestController
@@ -203,6 +204,36 @@ public class TenantController implements TenantApi, TenantadminApi {
   public ResponseEntity<TranslationResponseDTO> translate(
       TranslationRequestDTO translationRequestDTO) {
     return new ResponseEntity<>(translationFacade.translate(translationRequestDTO), HttpStatus.OK);
+  }
+
+  @Override
+  @PreAuthorize("hasAuthority('AUTHORIZATION_TRANSLATE_GROUP_CHAT_CONTENT')")
+  public ResponseEntity<TranslationResponseDTO> translateGroupChatAuthorContent(
+      TranslationRequestDTO translationRequestDTO) {
+    validateGroupChatAuthorContent(translationRequestDTO);
+    return new ResponseEntity<>(translationFacade.translate(translationRequestDTO), HttpStatus.OK);
+  }
+
+  private static void validateGroupChatAuthorContent(TranslationRequestDTO request) {
+    if (request == null
+        || request.getSourceLang() == null
+        || request.getSourceLang().isBlank()
+        || CollectionUtils.isEmpty(request.getTargetLangs())
+        || CollectionUtils.isEmpty(request.getTexts())
+        || request.getTexts().size() > 10
+        || request.getTargetLangs().size() > 10
+        || request.getTexts().entrySet().stream()
+            .anyMatch(
+                entry ->
+                    entry.getKey() == null
+                        || entry.getKey().isBlank()
+                        || entry.getKey().length() > 64
+                        || entry.getValue() == null
+                        || entry.getValue().isBlank()
+                        || entry.getValue().length() > 120)) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Invalid group-chat author content");
+    }
   }
 
   @ExceptionHandler(TranslationException.class)

--- a/src/main/java/com/vi/tenantservice/api/controller/TenantController.java
+++ b/src/main/java/com/vi/tenantservice/api/controller/TenantController.java
@@ -222,6 +222,8 @@ public class TenantController implements TenantApi, TenantadminApi {
         || CollectionUtils.isEmpty(request.getTexts())
         || request.getTexts().size() > 10
         || request.getTargetLangs().size() > 10
+        || request.getTargetLangs().stream()
+            .anyMatch(language -> language == null || language.isBlank() || language.length() > 10)
         || request.getTexts().entrySet().stream()
             .anyMatch(
                 entry ->

--- a/src/main/java/com/vi/tenantservice/api/facade/TenantServiceFacade.java
+++ b/src/main/java/com/vi/tenantservice/api/facade/TenantServiceFacade.java
@@ -243,9 +243,21 @@ public class TenantServiceFacade {
   }
 
   private void validateTranslationKeys(List<String> isoCountries, List<String> keys) {
-    if (!keys.isEmpty() && !isoCountries.containsAll(keys)) {
+    boolean hasInvalidKey =
+        keys.stream().anyMatch(key -> !isValidTranslationKey(isoCountries, key));
+    if (hasInvalidKey) {
       throw new TenantValidationException(HttpStatusExceptionReason.LANGUAGE_KEY_NOT_VALID);
     }
+  }
+
+  private boolean isValidTranslationKey(List<String> isoCountries, String key) {
+    if (isoCountries.contains(key)) {
+      return true;
+    }
+
+    String metadataSuffix = "__meta";
+    return key.endsWith(metadataSuffix)
+        && isoCountries.contains(key.substring(0, key.length() - metadataSuffix.length()));
   }
 
   private static List<String> getLanguageLowercaseKeys(Map<String, String> translatedMap) {

--- a/src/test/java/com/vi/tenantservice/api/authorisation/RoleAuthorizationAuthorityMapperTest.java
+++ b/src/test/java/com/vi/tenantservice/api/authorisation/RoleAuthorizationAuthorityMapperTest.java
@@ -1,0 +1,18 @@
+package com.vi.tenantservice.api.authorisation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class RoleAuthorizationAuthorityMapperTest {
+
+  @Test
+  void consultantReceivesOnlyTheBoundedGroupChatTranslationAuthority() {
+    var authorities = new RoleAuthorizationAuthorityMapper().mapAuthorities(Set.of("consultant"));
+
+    assertThat(authorities)
+        .extracting(authority -> authority.getAuthority())
+        .containsExactly(Authority.AuthorityValue.TRANSLATE_GROUP_CHAT_CONTENT);
+  }
+}

--- a/src/test/java/com/vi/tenantservice/api/controller/TenantControllerGroupChatTranslationTest.java
+++ b/src/test/java/com/vi/tenantservice/api/controller/TenantControllerGroupChatTranslationTest.java
@@ -1,0 +1,80 @@
+package com.vi.tenantservice.api.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.vi.tenantservice.api.facade.TenantDpaFacade;
+import com.vi.tenantservice.api.facade.TenantServiceFacade;
+import com.vi.tenantservice.api.facade.TranslationFacade;
+import com.vi.tenantservice.api.model.TranslationRequestDTO;
+import com.vi.tenantservice.api.model.TranslationResponseDTO;
+import com.vi.tenantservice.api.service.TenantDpaService;
+import com.vi.tenantservice.config.security.AuthorisationService;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.server.ResponseStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class TenantControllerGroupChatTranslationTest {
+
+  @Mock private TenantServiceFacade tenantServiceFacade;
+  @Mock private AuthorisationService authorisationService;
+  @Mock private TenantDtoMapper tenantDtoMapper;
+  @Mock private TenantDpaService tenantDpaService;
+  @Mock private TenantDpaFacade tenantDpaFacade;
+  @Mock private TranslationFacade translationFacade;
+  @InjectMocks private TenantController controller;
+
+  @Test
+  void boundedAuthorContentUsesTheExistingTranslationFacade() {
+    var request =
+        new TranslationRequestDTO()
+            .sourceLang("de")
+            .targetLangs(List.of("en"))
+            .texts(Map.of("welcome", "Willkommen"));
+    var translated =
+        new TranslationResponseDTO().translations(Map.of("en", Map.of("welcome", "Welcome")));
+    when(translationFacade.translate(request)).thenReturn(translated);
+
+    var response = controller.translateGroupChatAuthorContent(request);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isSameAs(translated);
+  }
+
+  @Test
+  void authorContentRejectsMessagesLongerThanTheSeriesContract() {
+    var request =
+        new TranslationRequestDTO()
+            .sourceLang("de")
+            .targetLangs(List.of("en"))
+            .texts(Map.of("rule-1", "x".repeat(121)));
+
+    assertThatThrownBy(() -> controller.translateGroupChatAuthorContent(request))
+        .isInstanceOf(ResponseStatusException.class)
+        .satisfies(
+            error ->
+                assertThat(((ResponseStatusException) error).getStatusCode())
+                    .isEqualTo(HttpStatus.BAD_REQUEST));
+    verifyNoInteractions(translationFacade);
+  }
+
+  @Test
+  void endpointRequiresTheDedicatedConsultantTranslationAuthority() throws Exception {
+    var method =
+        TenantController.class.getMethod(
+            "translateGroupChatAuthorContent", TranslationRequestDTO.class);
+
+    assertThat(method.getAnnotation(PreAuthorize.class).value())
+        .isEqualTo("hasAuthority('AUTHORIZATION_TRANSLATE_GROUP_CHAT_CONTENT')");
+  }
+}

--- a/src/test/java/com/vi/tenantservice/api/controller/TenantControllerGroupChatTranslationTest.java
+++ b/src/test/java/com/vi/tenantservice/api/controller/TenantControllerGroupChatTranslationTest.java
@@ -12,6 +12,10 @@ import com.vi.tenantservice.api.model.TranslationRequestDTO;
 import com.vi.tenantservice.api.model.TranslationResponseDTO;
 import com.vi.tenantservice.api.service.TenantDpaService;
 import com.vi.tenantservice.config.security.AuthorisationService;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -22,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.server.ResponseStatusException;
+import org.yaml.snakeyaml.Yaml;
 
 @ExtendWith(MockitoExtension.class)
 class TenantControllerGroupChatTranslationTest {
@@ -66,6 +71,40 @@ class TenantControllerGroupChatTranslationTest {
                 assertThat(((ResponseStatusException) error).getStatusCode())
                     .isEqualTo(HttpStatus.BAD_REQUEST));
     verifyNoInteractions(translationFacade);
+  }
+
+  @Test
+  void authorContentRejectsBlankAndNullTargetLanguages() {
+    for (var targetLangs : List.of(List.of(" "), Arrays.asList("en", null))) {
+      var request =
+          new TranslationRequestDTO()
+              .sourceLang("de")
+              .targetLangs(targetLangs)
+              .texts(Map.of("welcome", "Willkommen"));
+
+      assertThatThrownBy(() -> controller.translateGroupChatAuthorContent(request))
+          .isInstanceOf(ResponseStatusException.class)
+          .satisfies(
+              error ->
+                  assertThat(((ResponseStatusException) error).getStatusCode())
+                      .isEqualTo(HttpStatus.BAD_REQUEST));
+    }
+    verifyNoInteractions(translationFacade);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void openApiDocumentsEveryRoleAllowedToTranslateGroupChatContent() throws IOException {
+    Map<String, Object> specification =
+        new Yaml().load(Files.readString(Path.of("api/tenantservice.yaml")));
+    var paths = (Map<String, Object>) specification.get("paths");
+    var endpoint = (Map<String, Object>) paths.get("/tenant/translate/group-chat-author-content");
+    var post = (Map<String, Object>) endpoint.get("post");
+
+    assertThat(post.get("summary"))
+        .isEqualTo(
+            "Translates bounded self-help group welcome and rule content "
+                + "[Authorization: consultant, group-chat-consultant]");
   }
 
   @Test

--- a/src/test/java/com/vi/tenantservice/api/facade/TenantServiceFacadeTest.java
+++ b/src/test/java/com/vi/tenantservice/api/facade/TenantServiceFacadeTest.java
@@ -284,6 +284,27 @@ class TenantServiceFacadeTest {
   }
 
   @Test
+  void updateTenant_Should_passValidation_When_translationMetadataKeyIsValid() {
+    // given
+    when(tenantInputSanitizer.sanitize(tenantMultilingualDTO)).thenReturn(sanitizedTenantDTO);
+    when(tenantService.findTenantById(ID)).thenReturn(Optional.of(tenantEntity));
+    when(converter.toEntity(tenantEntity, sanitizedTenantDTO)).thenReturn(tenantEntity);
+    HashMap<String, String> privacy = Maps.newHashMap();
+    privacy.put("en", "english privacy text");
+    privacy.put("en__meta", "{\"mt\":true,\"src\":\"de\"}");
+    tenantMultilingualDTO.setContent(new MultilingualContent().privacy(privacy));
+    givenConsultingTypeReturnsConsultingTypeByTenantId();
+    when(tenantService.update(tenantEntity)).thenReturn(tenantEntity);
+    when(converter.toMultilingualDTO(tenantEntity)).thenReturn(sanitizedTenantDTO);
+
+    // when
+    tenantServiceFacade.updateTenant(ID, tenantMultilingualDTO);
+
+    // then
+    verify(tenantService).update(tenantEntity);
+  }
+
+  @Test
   void updateTenant_Should_ThrowTenantNotFoundException_When_IdNotFound() {
     // then
     assertThrows(


### PR DESCRIPTION
## Summary

- add the tenant-authorized group-chat author-content translation boundary
- preserve the established metadata locale key during tenant validation
- cover role mapping, controller authorization, translation success, and error paths
- validate each target language and document every authorized consultant role after review

## Why

This is the TenantService slice for OpenResilienceInitiative/ORISO-Frontend#396. It lets authors translate and edit per-Series welcome/rule content while retaining the existing tenant translation provider boundary.

## Verification

Exact head: `6f9ce310112efcc2009260d54d6f9b84a284296c`

- JDK 21 `clean package`: 259 tests, 0 failures, 0 errors; Spotless green
- focused RED→GREEN coverage rejects blank/null target languages before provider access
- endpoint-scoped OpenAPI contract proves both `consultant` and `group-chat-consultant` authorization documentation
- real Admin browser proof remains valid: the Self-Help Group Chat tenant toggle persists after reload
- based on and targeting `pre-dev`

GitHub Actions are running again on the exact review-fix head. Human developer approval is still required; this PR must not be merged by automation or pushed directly to `dev`/`main`.

Refs OpenResilienceInitiative/ORISO-Frontend#400
Refs OpenResilienceInitiative/ORISO-Frontend#396

🤖 Generated with [Claude Code](https://claude.com/claude-code)
