### PR TITLE
feat(controls): enforcedPermissionToggles + effective public settings (P1+P4 of Admin#291)

### DIFF
--- a/api/tenantservice.yaml
+++ b/api/tenantservice.yaml
@@ -1278,6 +1278,11 @@ components:
           example: "true"
         allowedPermissionToggles:
           $ref: '#/components/schemas/TenantAdminAllowedPermissionToggles'
+        # enforcedPermissionToggles: per-feature flags an upper role locks ON for every lower role
+        # (Platform -> Traeger -> Beratungsstelle). true = enforced-on; absent/false = not enforced.
+        # Same shape as allowedPermissionToggles. See ADR-013.
+        enforcedPermissionToggles:
+          $ref: '#/components/schemas/TenantAdminAllowedPermissionToggles'
 
     TenantAdminAllowedPermissionToggles:
       type: object

--- a/src/main/java/com/vi/tenantservice/api/converter/EffectivePermissionSettingsApplier.java
+++ b/src/main/java/com/vi/tenantservice/api/converter/EffectivePermissionSettingsApplier.java
@@ -1,0 +1,122 @@
+package com.vi.tenantservice.api.converter;
+
+import com.vi.tenantservice.api.model.Settings;
+import com.vi.tenantservice.api.model.TenantAdminAllowedPermissionToggles;
+import com.vi.tenantservice.api.model.TenantAdminControls;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import org.springframework.stereotype.Component;
+
+/**
+ * Applies an upper role's effective permission constraints (platform {@link TenantAdminControls})
+ * to the public feature flags served to the counselling app. {@code allowedPermissionToggles ==
+ * false} forces the feature off; {@code enforcedPermissionToggles == true} forces it on; anything
+ * else is left as the tenant set it. This is the server-side single source of truth so the Frontend
+ * needs no awareness of the controls (which are stripped from the restricted DTO). See ADR-013 P4.
+ */
+@Component
+public class EffectivePermissionSettingsApplier {
+
+  private record ToggleBinding(
+      Function<TenantAdminAllowedPermissionToggles, Boolean> getter,
+      BiConsumer<Settings, Boolean> setter) {}
+
+  // One binding per conversation feature: the toggle getter <-> the Settings feature-flag setter it
+  // governs. Mirrors ORISO-Admin's TOGGLE_KEY_TO_FIELD (note the irregular threadsOneOnOneChats ->
+  // featureThreadsOneOnOneEnabled).
+  private static final List<ToggleBinding> BINDINGS =
+      List.of(
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getAnonymousChat,
+              Settings::setFeatureAnonymousChatEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getGroupChat,
+              Settings::setFeatureGroupChatV2Enabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getCalls, Settings::setFeatureCallsEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getSupervision,
+              Settings::setFeatureSupervisionEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getSupervisionAnonymousChats,
+              Settings::setFeatureSupervisionAnonymousChatsEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getSupervisionOneOnOneChats,
+              Settings::setFeatureSupervisionOneOnOneChatsEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getAudioCalls,
+              Settings::setFeatureAudioCallsEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getAudioCallsAnonymousChats,
+              Settings::setFeatureAudioCallsAnonymousChatsEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getAudioCallsOneOnOneChats,
+              Settings::setFeatureAudioCallsOneOnOneChatsEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getAudioCallsGroupChats,
+              Settings::setFeatureAudioCallsGroupChatsEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getAudioCallsSupervisionChats,
+              Settings::setFeatureAudioCallsSupervisionChatsEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getVideoCalls,
+              Settings::setFeatureVideoCallsEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getVideoCallsAnonymousChats,
+              Settings::setFeatureVideoCallsAnonymousChatsEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getVideoCallsOneOnOneChats,
+              Settings::setFeatureVideoCallsOneOnOneChatsEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getVideoCallsGroupChats,
+              Settings::setFeatureVideoCallsGroupChatsEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getVideoCallsSupervisionChats,
+              Settings::setFeatureVideoCallsSupervisionChatsEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getThreads, Settings::setFeatureThreadsEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getThreadsAnonymousChats,
+              Settings::setFeatureThreadsAnonymousChatsEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getThreadsOneOnOneChats,
+              Settings::setFeatureThreadsOneOnOneEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getThreadsGroupChats,
+              Settings::setFeatureThreadsGroupChatsEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getThreadsSupervisionChats,
+              Settings::setFeatureThreadsSupervisionChatsEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getVoiceMessages,
+              Settings::setFeatureVoiceMessagesEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getVoiceMessagesAnonymousChats,
+              Settings::setFeatureVoiceMessagesAnonymousChatsEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getVoiceMessagesOneOnOneChats,
+              Settings::setFeatureVoiceMessagesOneOnOneChatsEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getVoiceMessagesGroupChats,
+              Settings::setFeatureVoiceMessagesGroupChatsEnabled),
+          new ToggleBinding(
+              TenantAdminAllowedPermissionToggles::getVoiceMessagesSupervisionChats,
+              Settings::setFeatureVoiceMessagesSupervisionChatsEnabled));
+
+  public void applyTo(Settings settings, TenantAdminControls controls) {
+    if (settings == null || controls == null) {
+      return;
+    }
+    TenantAdminAllowedPermissionToggles allowed = controls.getAllowedPermissionToggles();
+    TenantAdminAllowedPermissionToggles enforced = controls.getEnforcedPermissionToggles();
+    for (ToggleBinding binding : BINDINGS) {
+      if (allowed != null && Boolean.FALSE.equals(binding.getter().apply(allowed))) {
+        binding.setter().accept(settings, false);
+      }
+      if (enforced != null && Boolean.TRUE.equals(binding.getter().apply(enforced))) {
+        binding.setter().accept(settings, true);
+      }
+    }
+  }
+}

--- a/src/main/java/com/vi/tenantservice/api/converter/TenantConverter.java
+++ b/src/main/java/com/vi/tenantservice/api/converter/TenantConverter.java
@@ -296,6 +296,8 @@ public class TenantConverter {
         .allowedPermissionToggles(
             toTenantAdminAllowedPermissionTogglesSettings(
                 tenantAdminControls.getAllowedPermissionToggles()))
+        .enforcedPermissionToggles(
+            toEnforcedPermissionTogglesSettings(tenantAdminControls.getEnforcedPermissionToggles()))
         .build();
   }
 
@@ -353,7 +355,10 @@ public class TenantConverter {
         .permissionsPageEnabled(tenantAdminControlsSettings.isPermissionsPageEnabled())
         .allowedPermissionToggles(
             toTenantAdminAllowedPermissionToggles(
-                tenantAdminControlsSettings.getAllowedPermissionToggles()));
+                tenantAdminControlsSettings.getAllowedPermissionToggles()))
+        .enforcedPermissionToggles(
+            toEnforcedPermissionToggles(
+                tenantAdminControlsSettings.getEnforcedPermissionToggles()));
   }
 
   private TenantAdminAllowedPermissionToggles toTenantAdminAllowedPermissionToggles(
@@ -406,6 +411,103 @@ public class TenantConverter {
             nullAsTrue(allowedPermissionTogglesSettings.getVoiceMessagesGroupChats()))
         .voiceMessagesSupervisionChats(
             nullAsTrue(allowedPermissionTogglesSettings.getVoiceMessagesSupervisionChats()));
+  }
+
+  private TenantAdminAllowedPermissionTogglesSettings toEnforcedPermissionTogglesSettings(
+      TenantAdminAllowedPermissionToggles allowedPermissionToggles) {
+    if (allowedPermissionToggles == null) {
+      return null;
+    }
+    return TenantAdminAllowedPermissionTogglesSettings.builder()
+        .appearance(nullAsFalse(allowedPermissionToggles.getAppearance()))
+        .anonymousChat(nullAsFalse(allowedPermissionToggles.getAnonymousChat()))
+        .calls(nullAsFalse(allowedPermissionToggles.getCalls()))
+        .groupChat(nullAsFalse(allowedPermissionToggles.getGroupChat()))
+        .supervision(nullAsFalse(allowedPermissionToggles.getSupervision()))
+        .supervisionAnonymousChats(
+            nullAsFalse(allowedPermissionToggles.getSupervisionAnonymousChats()))
+        .supervisionOneOnOneChats(
+            nullAsFalse(allowedPermissionToggles.getSupervisionOneOnOneChats()))
+        .audioCalls(nullAsFalse(allowedPermissionToggles.getAudioCalls()))
+        .audioCallsAnonymousChats(
+            nullAsFalse(allowedPermissionToggles.getAudioCallsAnonymousChats()))
+        .audioCallsOneOnOneChats(nullAsFalse(allowedPermissionToggles.getAudioCallsOneOnOneChats()))
+        .audioCallsGroupChats(nullAsFalse(allowedPermissionToggles.getAudioCallsGroupChats()))
+        .audioCallsSupervisionChats(
+            nullAsFalse(allowedPermissionToggles.getAudioCallsSupervisionChats()))
+        .videoCalls(nullAsFalse(allowedPermissionToggles.getVideoCalls()))
+        .videoCallsAnonymousChats(
+            nullAsFalse(allowedPermissionToggles.getVideoCallsAnonymousChats()))
+        .videoCallsOneOnOneChats(nullAsFalse(allowedPermissionToggles.getVideoCallsOneOnOneChats()))
+        .videoCallsGroupChats(nullAsFalse(allowedPermissionToggles.getVideoCallsGroupChats()))
+        .videoCallsSupervisionChats(
+            nullAsFalse(allowedPermissionToggles.getVideoCallsSupervisionChats()))
+        .threads(nullAsFalse(allowedPermissionToggles.getThreads()))
+        .threadsAnonymousChats(nullAsFalse(allowedPermissionToggles.getThreadsAnonymousChats()))
+        .threadsOneOnOneChats(nullAsFalse(allowedPermissionToggles.getThreadsOneOnOneChats()))
+        .threadsGroupChats(nullAsFalse(allowedPermissionToggles.getThreadsGroupChats()))
+        .threadsSupervisionChats(nullAsFalse(allowedPermissionToggles.getThreadsSupervisionChats()))
+        .voiceMessages(nullAsFalse(allowedPermissionToggles.getVoiceMessages()))
+        .voiceMessagesAnonymousChats(
+            nullAsFalse(allowedPermissionToggles.getVoiceMessagesAnonymousChats()))
+        .voiceMessagesOneOnOneChats(
+            nullAsFalse(allowedPermissionToggles.getVoiceMessagesOneOnOneChats()))
+        .voiceMessagesGroupChats(nullAsFalse(allowedPermissionToggles.getVoiceMessagesGroupChats()))
+        .voiceMessagesSupervisionChats(
+            nullAsFalse(allowedPermissionToggles.getVoiceMessagesSupervisionChats()))
+        .build();
+  }
+
+  private TenantAdminAllowedPermissionToggles toEnforcedPermissionToggles(
+      TenantAdminAllowedPermissionTogglesSettings allowedPermissionTogglesSettings) {
+    if (allowedPermissionTogglesSettings == null) {
+      return null;
+    }
+    return new TenantAdminAllowedPermissionToggles()
+        .appearance(nullAsFalse(allowedPermissionTogglesSettings.getAppearance()))
+        .anonymousChat(nullAsFalse(allowedPermissionTogglesSettings.getAnonymousChat()))
+        .calls(nullAsFalse(allowedPermissionTogglesSettings.getCalls()))
+        .groupChat(nullAsFalse(allowedPermissionTogglesSettings.getGroupChat()))
+        .supervision(nullAsFalse(allowedPermissionTogglesSettings.getSupervision()))
+        .supervisionAnonymousChats(
+            nullAsFalse(allowedPermissionTogglesSettings.getSupervisionAnonymousChats()))
+        .supervisionOneOnOneChats(
+            nullAsFalse(allowedPermissionTogglesSettings.getSupervisionOneOnOneChats()))
+        .audioCalls(nullAsFalse(allowedPermissionTogglesSettings.getAudioCalls()))
+        .audioCallsAnonymousChats(
+            nullAsFalse(allowedPermissionTogglesSettings.getAudioCallsAnonymousChats()))
+        .audioCallsOneOnOneChats(
+            nullAsFalse(allowedPermissionTogglesSettings.getAudioCallsOneOnOneChats()))
+        .audioCallsGroupChats(
+            nullAsFalse(allowedPermissionTogglesSettings.getAudioCallsGroupChats()))
+        .audioCallsSupervisionChats(
+            nullAsFalse(allowedPermissionTogglesSettings.getAudioCallsSupervisionChats()))
+        .videoCalls(nullAsFalse(allowedPermissionTogglesSettings.getVideoCalls()))
+        .videoCallsAnonymousChats(
+            nullAsFalse(allowedPermissionTogglesSettings.getVideoCallsAnonymousChats()))
+        .videoCallsOneOnOneChats(
+            nullAsFalse(allowedPermissionTogglesSettings.getVideoCallsOneOnOneChats()))
+        .videoCallsGroupChats(
+            nullAsFalse(allowedPermissionTogglesSettings.getVideoCallsGroupChats()))
+        .videoCallsSupervisionChats(
+            nullAsFalse(allowedPermissionTogglesSettings.getVideoCallsSupervisionChats()))
+        .threads(nullAsFalse(allowedPermissionTogglesSettings.getThreads()))
+        .threadsAnonymousChats(
+            nullAsFalse(allowedPermissionTogglesSettings.getThreadsAnonymousChats()))
+        .threadsOneOnOneChats(
+            nullAsFalse(allowedPermissionTogglesSettings.getThreadsOneOnOneChats()))
+        .threadsGroupChats(nullAsFalse(allowedPermissionTogglesSettings.getThreadsGroupChats()))
+        .threadsSupervisionChats(
+            nullAsFalse(allowedPermissionTogglesSettings.getThreadsSupervisionChats()))
+        .voiceMessages(nullAsFalse(allowedPermissionTogglesSettings.getVoiceMessages()))
+        .voiceMessagesAnonymousChats(
+            nullAsFalse(allowedPermissionTogglesSettings.getVoiceMessagesAnonymousChats()))
+        .voiceMessagesOneOnOneChats(
+            nullAsFalse(allowedPermissionTogglesSettings.getVoiceMessagesOneOnOneChats()))
+        .voiceMessagesGroupChats(
+            nullAsFalse(allowedPermissionTogglesSettings.getVoiceMessagesGroupChats()))
+        .voiceMessagesSupervisionChats(
+            nullAsFalse(allowedPermissionTogglesSettings.getVoiceMessagesSupervisionChats()));
   }
 
   private TenantSmtpSettings toTenantSmtpSettings(SmtpConfig smtpConfig) {

--- a/src/main/java/com/vi/tenantservice/api/facade/TenantServiceFacade.java
+++ b/src/main/java/com/vi/tenantservice/api/facade/TenantServiceFacade.java
@@ -8,6 +8,7 @@ import static org.springframework.util.ObjectUtils.nullSafeEquals;
 import com.google.common.collect.Lists;
 import com.vi.tenantservice.api.authorisation.Authority.AuthorityValue;
 import com.vi.tenantservice.api.converter.ConsultingTypePatchDTOConverter;
+import com.vi.tenantservice.api.converter.EffectivePermissionSettingsApplier;
 import com.vi.tenantservice.api.converter.TenantConverter;
 import com.vi.tenantservice.api.exception.ConsultingTypeCreationException;
 import com.vi.tenantservice.api.exception.TenantNotFoundException;
@@ -86,6 +87,8 @@ public class TenantServiceFacade {
       tenantFacadeDependentSettingsOverrideService;
 
   private final @NonNull TenantAdminControlsService tenantAdminControlsService;
+
+  private final @NonNull EffectivePermissionSettingsApplier effectivePermissionSettingsApplier;
 
   private final @NonNull TenantResolverService tenantResolverService;
 
@@ -431,7 +434,22 @@ public class TenantServiceFacade {
     String lang = translationService.getCurrentLanguageContext();
     return tenantById.isEmpty()
         ? Optional.empty()
-        : Optional.of(tenantConverter.toRestrictedTenantDTO(tenantById.get(), lang));
+        : Optional.of(
+            withEffectivePermissions(
+                tenantConverter.toRestrictedTenantDTO(tenantById.get(), lang)));
+  }
+
+  /**
+   * Bakes the platform admin controls into the public settings so the counselling app receives
+   * effective feature flags (forced-off disabled, enforced-on locked on) without seeing the
+   * controls themselves. See ADR-013 P4.
+   */
+  private RestrictedTenantDTO withEffectivePermissions(RestrictedTenantDTO dto) {
+    if (dto != null) {
+      effectivePermissionSettingsApplier.applyTo(
+          dto.getSettings(), tenantAdminControlsService.getControls());
+    }
+    return dto;
   }
 
   public List<BasicTenantLicensingDTO> getAllTenants() {
@@ -452,7 +470,9 @@ public class TenantServiceFacade {
     String lang = translationService.getCurrentLanguageContext();
     return tenantBySubdomain.isEmpty()
         ? Optional.empty()
-        : Optional.of(tenantConverter.toRestrictedTenantDTO(tenantBySubdomain.get(), lang));
+        : Optional.of(
+            withEffectivePermissions(
+                tenantConverter.toRestrictedTenantDTO(tenantBySubdomain.get(), lang)));
   }
 
   private Optional<Long> resolveFromRequestOrCookie(Long optionalTenantIdOverride) {
@@ -481,8 +501,9 @@ public class TenantServiceFacade {
     Long actualTenantId = tenantResolverService.tryResolve().orElseThrow();
     TenantRestrictedData actualTenant =
         tenantService.findRestrictedTenantDataById(actualTenantId).orElseThrow();
-    return singleDomainTenantOverrideService.overridePrivacyAndCertainSettings(
-        mainTenant, actualTenant);
+    return withEffectivePermissions(
+        singleDomainTenantOverrideService.overridePrivacyAndCertainSettings(
+            mainTenant, actualTenant));
   }
 
   public Optional<RestrictedTenantDTO> getTenantDataWithOverride(
@@ -498,8 +519,9 @@ public class TenantServiceFacade {
       throw new BadRequestException("Tenant not found for id " + resolvedTenantId);
     }
     return Optional.of(
-        singleDomainTenantOverrideService.overridePrivacyAndCertainSettings(
-            mainTenantForSingleDomainMultitenancy.get(), tenantToOverridePrivacy.get()));
+        withEffectivePermissions(
+            singleDomainTenantOverrideService.overridePrivacyAndCertainSettings(
+                mainTenantForSingleDomainMultitenancy.get(), tenantToOverridePrivacy.get())));
   }
 
   public Optional<RestrictedTenantDTO> getSingleTenant() {
@@ -507,7 +529,8 @@ public class TenantServiceFacade {
     if (tenantEntities != null && tenantEntities.size() == 1) {
       var tenantEntity = tenantEntities.get(0);
       String lang = translationService.getCurrentLanguageContext();
-      return Optional.of(tenantConverter.toRestrictedTenantDTO(tenantEntity, lang));
+      return Optional.of(
+          withEffectivePermissions(tenantConverter.toRestrictedTenantDTO(tenantEntity, lang)));
     } else {
       throw new IllegalStateException("Not exactly one tenant was found.");
     }

--- a/src/main/java/com/vi/tenantservice/api/model/TenantAdminControlsSettings.java
+++ b/src/main/java/com/vi/tenantservice/api/model/TenantAdminControlsSettings.java
@@ -15,6 +15,14 @@ public class TenantAdminControlsSettings {
   TenantAdminAllowedPermissionTogglesSettings allowedPermissionToggles;
 
   /**
+   * Per-feature flags an upper role locks <em>on</em> for every lower role (Platform -> Träger ->
+   * Beratungsstelle). {@code true} = enforced-on (lower roles cannot hide it); absent/{@code false}
+   * = not enforced. Same shape as {@link #allowedPermissionToggles}. See ADR-013. Stored in the
+   * same JSON blob; absent on legacy rows (backward compatible).
+   */
+  TenantAdminAllowedPermissionTogglesSettings enforcedPermissionToggles;
+
+  /**
    * Platform-global machine-translation provider API keys (provider id -> raw key), e.g.
    * "openrouter"/"mistral". Stored in the same tenant_admin_controls JSON blob as the other
    * platform-global admin settings. Never exposed through the TenantAdminControls DTO - dedicated

--- a/src/test/java/com/vi/tenantservice/api/converter/EffectivePermissionSettingsApplierTest.java
+++ b/src/test/java/com/vi/tenantservice/api/converter/EffectivePermissionSettingsApplierTest.java
@@ -1,0 +1,73 @@
+package com.vi.tenantservice.api.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.vi.tenantservice.api.model.Settings;
+import com.vi.tenantservice.api.model.TenantAdminAllowedPermissionToggles;
+import com.vi.tenantservice.api.model.TenantAdminControls;
+import org.junit.jupiter.api.Test;
+
+class EffectivePermissionSettingsApplierTest {
+
+  private final EffectivePermissionSettingsApplier applier =
+      new EffectivePermissionSettingsApplier();
+
+  @Test
+  void applyTo_should_forceFeatureOff_whenUpperRoleDisallowsIt() {
+    var settings = new Settings().featureVideoCallsEnabled(true);
+    var controls =
+        new TenantAdminControls()
+            .allowedPermissionToggles(new TenantAdminAllowedPermissionToggles().videoCalls(false));
+
+    applier.applyTo(settings, controls);
+
+    assertThat(settings.getFeatureVideoCallsEnabled()).isFalse();
+  }
+
+  @Test
+  void applyTo_should_forceFeatureOn_whenUpperRoleEnforcesIt() {
+    var settings = new Settings().featureAudioCallsEnabled(false);
+    var controls =
+        new TenantAdminControls()
+            .enforcedPermissionToggles(new TenantAdminAllowedPermissionToggles().audioCalls(true));
+
+    applier.applyTo(settings, controls);
+
+    assertThat(settings.getFeatureAudioCallsEnabled()).isTrue();
+  }
+
+  @Test
+  void applyTo_should_leaveUnconstrainedFeatureUnchanged() {
+    var settings = new Settings().featureThreadsEnabled(true);
+    var controls =
+        new TenantAdminControls()
+            .allowedPermissionToggles(new TenantAdminAllowedPermissionToggles());
+
+    applier.applyTo(settings, controls);
+
+    assertThat(settings.getFeatureThreadsEnabled()).isTrue();
+  }
+
+  @Test
+  void applyTo_should_doNothing_whenControlsAreNull() {
+    var settings = new Settings().featureVideoCallsEnabled(true);
+
+    applier.applyTo(settings, null);
+
+    assertThat(settings.getFeatureVideoCallsEnabled()).isTrue();
+  }
+
+  @Test
+  void applyTo_should_mapTheIrregularOneOnOneThreadsField() {
+    // threadsOneOnOneChats maps to the irregularly named featureThreadsOneOnOneEnabled field.
+    var settings = new Settings().featureThreadsOneOnOneEnabled(true);
+    var controls =
+        new TenantAdminControls()
+            .allowedPermissionToggles(
+                new TenantAdminAllowedPermissionToggles().threadsOneOnOneChats(false));
+
+    applier.applyTo(settings, controls);
+
+    assertThat(settings.getFeatureThreadsOneOnOneEnabled()).isFalse();
+  }
+}

--- a/src/test/java/com/vi/tenantservice/api/converter/TenantConverterTest.java
+++ b/src/test/java/com/vi/tenantservice/api/converter/TenantConverterTest.java
@@ -293,6 +293,74 @@ class TenantConverterTest {
   }
 
   @Test
+  void toDTO_should_preserveEnforcedPermissionToggle() {
+    // given
+    MultilingualTenantDTO tenantDTO =
+        new MultilingualTenantTestDataBuilder().tenantDTO().withSettings().build();
+    tenantDTO
+        .getSettings()
+        .tenantAdminControls(
+            new TenantAdminControls()
+                .enforcedPermissionToggles(
+                    new TenantAdminAllowedPermissionToggles().videoCalls(true)));
+
+    // when
+    TenantDTO converted = tenantConverter.toDTO(tenantConverter.toEntity(tenantDTO), "de");
+
+    // then
+    assertThat(
+            converted
+                .getSettings()
+                .getTenantAdminControls()
+                .getEnforcedPermissionToggles()
+                .getVideoCalls())
+        .isTrue();
+  }
+
+  @Test
+  void toDTO_should_defaultMissingEnforcedPermissionToggleToFalse() {
+    // given - unlike allowed (defaults true), an unset enforced flag means "not enforced" = false
+    MultilingualTenantDTO tenantDTO =
+        new MultilingualTenantTestDataBuilder().tenantDTO().withSettings().build();
+    tenantDTO
+        .getSettings()
+        .tenantAdminControls(
+            new TenantAdminControls()
+                .enforcedPermissionToggles(new TenantAdminAllowedPermissionToggles()));
+
+    // when
+    TenantDTO converted = tenantConverter.toDTO(tenantConverter.toEntity(tenantDTO), "de");
+
+    // then
+    assertThat(
+            converted
+                .getSettings()
+                .getTenantAdminControls()
+                .getEnforcedPermissionToggles()
+                .getVideoCalls())
+        .isFalse();
+  }
+
+  @Test
+  void toDTO_should_keepEnforcedTogglesNullWhenAbsent() {
+    // given - a legacy row / DTO without enforcedPermissionToggles stays null (nothing enforced)
+    MultilingualTenantDTO tenantDTO =
+        new MultilingualTenantTestDataBuilder().tenantDTO().withSettings().build();
+    tenantDTO
+        .getSettings()
+        .tenantAdminControls(
+            new TenantAdminControls()
+                .allowedPermissionToggles(new TenantAdminAllowedPermissionToggles()));
+
+    // when
+    TenantDTO converted = tenantConverter.toDTO(tenantConverter.toEntity(tenantDTO), "de");
+
+    // then
+    assertThat(converted.getSettings().getTenantAdminControls().getEnforcedPermissionToggles())
+        .isNull();
+  }
+
+  @Test
   void toDTO_should_preserveSensitiveSettingsForNonPublicDtos() {
     // given
     MultilingualTenantDTO tenantDTO =

--- a/src/test/java/com/vi/tenantservice/api/facade/TenantServiceFacadeTest.java
+++ b/src/test/java/com/vi/tenantservice/api/facade/TenantServiceFacadeTest.java
@@ -14,6 +14,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.vi.tenantservice.api.authorisation.Authority.AuthorityValue;
 import com.vi.tenantservice.api.converter.ConsultingTypePatchDTOConverter;
+import com.vi.tenantservice.api.converter.EffectivePermissionSettingsApplier;
 import com.vi.tenantservice.api.converter.TenantConverter;
 import com.vi.tenantservice.api.exception.TenantNotFoundException;
 import com.vi.tenantservice.api.exception.TenantValidationException;
@@ -23,6 +24,8 @@ import com.vi.tenantservice.api.model.MultilingualContent;
 import com.vi.tenantservice.api.model.MultilingualTenantDTO;
 import com.vi.tenantservice.api.model.RestrictedTenantDTO;
 import com.vi.tenantservice.api.model.Settings;
+import com.vi.tenantservice.api.model.TenantAdminAllowedPermissionToggles;
+import com.vi.tenantservice.api.model.TenantAdminControls;
 import com.vi.tenantservice.api.model.TenantDTO;
 import com.vi.tenantservice.api.model.TenantEntity;
 import com.vi.tenantservice.api.model.TenantRestrictedData;
@@ -51,6 +54,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -107,6 +111,10 @@ class TenantServiceFacadeTest {
   private TenantFacadeDependentSettingsOverrideService tenantFacadeDependentSettingsOverrideService;
 
   @Mock private TenantAdminControlsService tenantAdminControlsService;
+
+  @Spy
+  private EffectivePermissionSettingsApplier effectivePermissionSettingsApplier =
+      new EffectivePermissionSettingsApplier();
 
   @Mock private SingleDomainTenantOverrideService singleDomainTenantOverrideService;
 
@@ -481,6 +489,28 @@ class TenantServiceFacadeTest {
     // then
     verify(tenantService).getAllTenantData();
     verify(converter).toRestrictedTenantDTO(tenantEntity, DE);
+  }
+
+  @Test
+  void getSingleTenant_Should_applyEffectivePlatformControls_toPublicSettings() {
+    // given: platform disallows video calls; the tenant itself has them on
+    var publicDto =
+        new RestrictedTenantDTO().settings(new Settings().featureVideoCallsEnabled(true));
+    when(tenantService.getAllTenantData()).thenReturn(List.of(tenantEntity));
+    when(translationService.getCurrentLanguageContext()).thenReturn(DE);
+    when(converter.toRestrictedTenantDTO(tenantEntity, DE)).thenReturn(publicDto);
+    when(tenantAdminControlsService.getControls())
+        .thenReturn(
+            new TenantAdminControls()
+                .allowedPermissionToggles(
+                    new TenantAdminAllowedPermissionToggles().videoCalls(false)));
+
+    // when
+    var result = tenantServiceFacade.getSingleTenant();
+
+    // then: the public settings served to the counselling app reflect the platform constraint
+    assertThat(result).isPresent();
+    assertThat(result.get().getSettings().getFeatureVideoCallsEnabled()).isFalse();
   }
 
   @Test


### PR DESCRIPTION
Backbone (P1) + effective public settings (P4) for the three-level permission cascade — see OpenResilienceInitiative/ORISO-Admin#291 / ADR-013.

**Problem:** Admin controls could only *force a feature off*; there was no *force on*; and the public tenant settings served to the counselling app did not reflect the platform's constraints.

**What changed**
- P1 — api/model/converter: `enforcedPermissionToggles` on `TenantAdminControls` (same shape as allowed), stored in the existing controls JSON blob (no DB migration), `nullAsFalse` semantics.
- P4 — `EffectivePermissionSettingsApplier`: applies the platform controls to the public `RestrictedTenantDTO` settings (allowed=false → off, enforced=true → on), wired into every restricted path in `TenantServiceFacade`. The controls stay stripped from the public DTO, so the Frontend needs **no change** — it already reads the (now effective) flags.

**Verification:** `mvnw test` — full suite green (converter 16/16, applier 5/5, facade 24/24); spotless clean.

Backward-compatible. Mirrors ORISO-AgencyService#119 (agency level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
